### PR TITLE
lmmx/version pin and repo url metadata fixes

### DIFF
--- a/inference_lib/setup.cfg
+++ b/inference_lib/setup.cfg
@@ -32,7 +32,7 @@ include_package_data = True
 python_requires = >=3.10
 install_requires =
     torch>=2.1.1
-    transformers==4.37.0
+    transformers>=4.37.0
 [options.extras_require]
 gpu =
     triton>=2.1

--- a/inference_lib/setup.cfg
+++ b/inference_lib/setup.cfg
@@ -6,9 +6,9 @@ author_email = vahe527887@yandex.ru
 description = Efficiently run models quantized with AQLM
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/Vage1994/AQLM
+url = https://github.com/Vahe1994/AQLM
 project_urls =
-    Bug Tracker = https://github.com/Vage1994/AQLM/issues
+    Bug Tracker = https://github.com/Vahe1994/AQLM/issues
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers


### PR DESCRIPTION
- fix: URL typo in repo metadata (closes #21)
- fix: relax `transformers` pin to lower bound (closes #22)
