### PR TITLE
Integrating with `autograd`, adding static kernel routing.

### DIFF
--- a/inference_lib/setup.cfg
+++ b/inference_lib/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aqlm
-version = 1.0.0
+version = 1.0.2dev
 author = AQLM paper authors
 author_email = vahe527887@yandex.ru
 description = Efficiently run models quantized with AQLM

--- a/inference_lib/setup.cfg
+++ b/inference_lib/setup.cfg
@@ -15,6 +15,8 @@ classifiers =
     Intended Audience :: Science/Research
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering
@@ -29,7 +31,7 @@ package_dir =
     = src
 packages = find:
 include_package_data = True
-python_requires = >=3.10
+python_requires = >=3.8
 install_requires =
     torch>=2.1.1
     transformers>=4.37.0

--- a/inference_lib/setup.cfg
+++ b/inference_lib/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aqlm
-version = 1.0.2dev
+version = 1.0.2
 author = AQLM paper authors
 author_email = vahe527887@yandex.ru
 description = Efficiently run models quantized with AQLM

--- a/inference_lib/src/aqlm/__init__.py
+++ b/inference_lib/src/aqlm/__init__.py
@@ -1,2 +1,3 @@
 import aqlm.inference_kernels
 from aqlm.inference import QuantizedLinear
+from aqlm.inference_kernels import optimize_for_training

--- a/inference_lib/src/aqlm/inference.py
+++ b/inference_lib/src/aqlm/inference.py
@@ -1,7 +1,7 @@
 """ Core mathematics for Additive Quantization (AQ): initialization, reconstruction and beam search"""
 import torch
 import torch.nn as nn
-from aqlm.inference_kernels import forward_pass_quantized_linear
+from aqlm.inference_kernels import QuantizedMatmul
 from aqlm.utils import get_int_dtype
 
 
@@ -34,24 +34,28 @@ class QuantizedLinear(nn.Module):
 
         # CODES & CODEBOOKS
         self.codebooks = nn.Parameter(
-            torch.empty((num_codebooks, self.codebook_size, out_group_size, in_group_size), **factory_kwargs),
-            requires_grad=True,
+            torch.rand((num_codebooks, self.codebook_size, out_group_size, in_group_size), **factory_kwargs) * 1e-3,
+            requires_grad=False,
         )  # [num_codebooks, codebook_size, out_group_size, in_group_size]
         self.codes = nn.Parameter(
-            torch.empty(
-                (num_out_groups, num_in_groups, num_codebooks), device=device, dtype=get_int_dtype(nbits_per_codebook)
+            torch.randint(
+                0,
+                256,
+                (num_out_groups, num_in_groups, num_codebooks),
+                device=device,
+                dtype=get_int_dtype(nbits_per_codebook),
             ),
             requires_grad=False,
         )  #  [num_out_groups, num_in_groups, num_codebooks]
 
         # SCALES
         self.scales = nn.Parameter(
-            torch.empty((num_out_groups, 1, 1, 1), **factory_kwargs), requires_grad=True
+            torch.ones((num_out_groups, 1, 1, 1), **factory_kwargs), requires_grad=False
         )  #  [num_out_groups, 1, 1, 1]
 
         # BIAS
         if bias:
-            self.bias = nn.Parameter(torch.empty(out_features, **factory_kwargs))
+            self.bias = nn.Parameter(torch.empty(out_features, **factory_kwargs), requires_grad=False)
         else:
             self.register_parameter("bias", None)
 
@@ -62,4 +66,4 @@ class QuantizedLinear(nn.Module):
             and self.codes.shape[0] == self.out_features // self.out_group_size
         ):
             self.codes.data = torch.permute(self.codes.data, (1, 0, 2)).contiguous()  #  TODO: fix this thing
-        return forward_pass_quantized_linear(input, self.codes, self.codebooks, self.scales, self.bias)
+        return QuantizedMatmul.apply(input, self.codes, self.codebooks, self.scales, self.bias)

--- a/inference_lib/src/aqlm/inference.py
+++ b/inference_lib/src/aqlm/inference.py
@@ -1,6 +1,7 @@
 """ Core mathematics for Additive Quantization (AQ): initialization, reconstruction and beam search"""
 import torch
 import torch.nn as nn
+
 from aqlm.inference_kernels import QuantizedMatmul
 from aqlm.utils import get_int_dtype
 

--- a/inference_lib/src/aqlm/inference.py
+++ b/inference_lib/src/aqlm/inference.py
@@ -1,10 +1,9 @@
 """ Core mathematics for Additive Quantization (AQ): initialization, reconstruction and beam search"""
 from typing import Optional
 
+import aqlm
 import torch
 import torch.nn as nn
-
-import aqlm
 from aqlm.inference_kernels import get_backward_pass_kernel, get_forward_pass_kernel
 from aqlm.utils import get_int_dtype
 

--- a/inference_lib/src/aqlm/inference.py
+++ b/inference_lib/src/aqlm/inference.py
@@ -35,13 +35,11 @@ class QuantizedLinear(nn.Module):
 
         # CODES & CODEBOOKS
         self.codebooks = nn.Parameter(
-            torch.rand((num_codebooks, self.codebook_size, out_group_size, in_group_size), **factory_kwargs) * 1e-3,
+            torch.empty((num_codebooks, self.codebook_size, out_group_size, in_group_size), **factory_kwargs),
             requires_grad=False,
         )  # [num_codebooks, codebook_size, out_group_size, in_group_size]
         self.codes = nn.Parameter(
-            torch.randint(
-                0,
-                256,
+            torch.empty(
                 (num_out_groups, num_in_groups, num_codebooks),
                 device=device,
                 dtype=get_int_dtype(nbits_per_codebook),
@@ -51,7 +49,7 @@ class QuantizedLinear(nn.Module):
 
         # SCALES
         self.scales = nn.Parameter(
-            torch.ones((num_out_groups, 1, 1, 1), **factory_kwargs), requires_grad=False
+            torch.empty((num_out_groups, 1, 1, 1), **factory_kwargs), requires_grad=False
         )  #  [num_out_groups, 1, 1, 1]
 
         # BIAS

--- a/inference_lib/src/aqlm/inference_kernels/__init__.py
+++ b/inference_lib/src/aqlm/inference_kernels/__init__.py
@@ -1,1 +1,1 @@
-from .kernel_selector import forward_pass_quantized_linear
+from .kernel_selector import QuantizedMatmul

--- a/inference_lib/src/aqlm/inference_kernels/__init__.py
+++ b/inference_lib/src/aqlm/inference_kernels/__init__.py
@@ -1,1 +1,1 @@
-from .kernel_selector import QuantizedMatmul
+from .kernel_selector import get_backward_pass_kernel, get_forward_pass_kernel

--- a/inference_lib/src/aqlm/inference_kernels/__init__.py
+++ b/inference_lib/src/aqlm/inference_kernels/__init__.py
@@ -1,1 +1,1 @@
-from .kernel_selector import get_backward_pass_kernel, get_forward_pass_kernel
+from .kernel_selector import get_backward_pass_kernel, get_forward_pass_kernel, optimize_for_training

--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
@@ -121,9 +121,9 @@ torch::Tensor code2x8_matmat(
   return output;
 }
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def("code1x16_matvec", &code1x16_matvec, "1x16 (2bit) codebook matrix-vector product.");
-  m.def("code1x16_matmat", &code1x16_matmat, "1x16 (2bit) codebook matrix-matrix product.");
-  m.def("code2x8_matvec", &code2x8_matvec, "2x8 (2bit) codebook matrix-vector product.");
-  m.def("code2x8_matmat", &code2x8_matmat, "2x8 (2bit) codebook matrix-matrix product.");
+TORCH_LIBRARY(aqlm_cuda_kernel, m) {
+  m.def("code1x16_matvec", code1x16_matvec);
+  m.def("code1x16_matmat", code1x16_matmat);
+  m.def("code2x8_matvec", code2x8_matvec);
+  m.def("code2x8_matmat", code2x8_matmat);
 }

--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
@@ -73,7 +73,7 @@ torch::Tensor code1x16_matmat(
   auto output_sizes = input_sizes.vec();
   output_sizes.pop_back();
   output_sizes.push_back(-1);
-  auto output = flat_output.view(output_sizes);
+  auto output = flat_output.reshape(output_sizes).clone();
   return output;
 }
 
@@ -130,7 +130,7 @@ torch::Tensor code2x8_matmat(
   auto output_sizes = input_sizes.vec();
   output_sizes.pop_back();
   output_sizes.push_back(-1);
-  auto output = flat_output.view(output_sizes);
+  auto output = flat_output.reshape(output_sizes).clone();
   return output;
 }
 

--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
@@ -41,7 +41,8 @@ torch::Tensor code1x16_matmat(
   const torch::Tensor& input,
   const torch::Tensor& codes,
   const torch::Tensor& codebooks,
-  const torch::Tensor& scales
+  const torch::Tensor& scales,
+  const std::optional<torch::Tensor>& bias
 ) {
   auto input_sizes = input.sizes();
   auto out_features = codes.size(0) * codebooks.size(2);
@@ -63,6 +64,10 @@ torch::Tensor code1x16_matmat(
     );
   }
   flat_output *= scales.flatten().unsqueeze(0);
+  if (bias.has_value()) {
+    flat_output += bias->unsqueeze(0);
+  }
+
   auto output_sizes = input_sizes.vec();
   output_sizes.pop_back();
   output_sizes.push_back(-1);
@@ -92,7 +97,8 @@ torch::Tensor code2x8_matmat(
   const torch::Tensor& input,
   const torch::Tensor& codes,
   const torch::Tensor& codebooks,
-  const torch::Tensor& scales
+  const torch::Tensor& scales,
+  const std::optional<torch::Tensor>& bias
 ) {
   auto input_sizes = input.sizes();
   auto out_features = codes.size(0) * codebooks.size(2);
@@ -114,6 +120,10 @@ torch::Tensor code2x8_matmat(
     );
   }
   flat_output *= scales.flatten().unsqueeze(0);
+  if (bias.has_value()) {
+    flat_output += bias->unsqueeze(0);
+  }
+
   auto output_sizes = input_sizes.vec();
   output_sizes.pop_back();
   output_sizes.push_back(-1);

--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
@@ -1,5 +1,6 @@
 #include <torch/all.h>
 #include <torch/python.h>
+#include <c10/cuda/CUDAGuard.h>
 
 void code1x16_matvec_cuda(
   const void* A,
@@ -25,6 +26,7 @@ void code1x16_matvec(
         torch::Tensor& C,
   const torch::Tensor& codebook
 ) {
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
   int prob_m = C.size(0);
   int prob_k = B.size(0);
   code1x16_matvec_cuda(
@@ -81,6 +83,7 @@ void code2x8_matvec(
         torch::Tensor& C,
   const torch::Tensor& codebook
 ) {
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
   int prob_m = C.size(0);
   int prob_k = B.size(0);
   code2x8_matvec_cuda(

--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.py
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.py
@@ -5,7 +5,8 @@ import torch
 from torch.utils.cpp_extension import load
 
 CUDA_FOLDER = os.path.dirname(os.path.abspath(__file__))
-CUDA_KERNEL = load(
+load(
     name="codebook_cuda",
     sources=[os.path.join(CUDA_FOLDER, "cuda_kernel.cpp"), os.path.join(CUDA_FOLDER, "cuda_kernel.cu")],
+    is_python_module=False,
 )

--- a/inference_lib/src/aqlm/inference_kernels/dequantization.py
+++ b/inference_lib/src/aqlm/inference_kernels/dequantization.py
@@ -1,0 +1,22 @@
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from aqlm.utils import _dequantize_weight, unpack_int_data
+
+
+def dequantize_gemm(
+    input: torch.Tensor,  #  [..., in_features]
+    codes: torch.IntTensor,  #  [num_out_groups, num_in_groups, num_codebooks]
+    codebooks: torch.Tensor,  #  [num_codebooks, codebook_size, out_group_size, in_group_size]
+    scales: torch.Tensor,  #  [num_out_groups, 1, 1, 1]
+    bias: Optional[torch.Tensor],
+) -> torch.Tensor:
+    dequantized_weight = _dequantize_weight(
+        unpack_int_data(codes, codebooks.shape[1].bit_length() - 1),
+        codebooks,
+        scales,
+    )
+    return F.linear(input, dequantized_weight, bias)

--- a/inference_lib/src/aqlm/inference_kernels/dequantization.py
+++ b/inference_lib/src/aqlm/inference_kernels/dequantization.py
@@ -2,9 +2,8 @@ from typing import Optional
 
 import torch
 import torch.nn.functional as F
-from torch import nn
-
 from aqlm.utils import _dequantize_weight, unpack_int_data
+from torch import nn
 
 
 def dequantize_gemm(

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -16,19 +16,23 @@ def forward_pass_quantized_linear(
     num_codebooks, codebook_size, out_group_size, in_group_size = codebooks.shape
     match (input.is_cuda, num_codebooks, codebook_size, out_group_size, in_group_size):
         case (True, 1, 65536, 1, 8):
-            from .cuda_kernel import CUDA_KERNEL
+            from .cuda_kernel import CUDA_FOLDER
 
             assert (
                 input.dtype == torch.float16
             ), f"please load the model with `torch_dtype=torch.float16`, as {input.dtype} is not supported on GPU yet"
-            return CUDA_KERNEL.code1x16_matmat(input, codes, codebooks, scales) + (bias if bias is not None else 0)
+            return torch.ops.aqlm_cuda_kernel.code1x16_matmat(input, codes, codebooks, scales) + (
+                bias if bias is not None else 0
+            )
         case (True, 2, 256, 1, 8):
-            from .cuda_kernel import CUDA_KERNEL
+            from .cuda_kernel import CUDA_FOLDER
 
             assert (
                 input.dtype == torch.float16
             ), f"please load the model with `torch_dtype=torch.float16`, as {input.dtype} is not supported on GPU yet"
-            return CUDA_KERNEL.code2x8_matmat(input, codes, codebooks, scales) + (bias if bias is not None else 0)
+            return torch.ops.aqlm_cuda_kernel.code2x8_matmat(input, codes, codebooks, scales) + (
+                bias if bias is not None else 0
+            )
         case (True, _, _, _, _):
             from .triton_kernel import triton_matmul
 
@@ -39,8 +43,67 @@ def forward_pass_quantized_linear(
             return numba_gemm_lut(input, codes, codebooks, scales, bias)
         case _:
             dequantized_weight = _dequantize_weight(
-                unpack_int_data(codes, codebooks.shape[0].bit_length() - 1),
+                unpack_int_data(codes, codebooks.shape[1].bit_length() - 1),
                 codebooks,
                 scales,
             )
             return F.linear(input, dequantized_weight, bias)
+
+
+def backward_pass_quantized_linear(
+    grad_output: torch.Tensor,
+    codes: torch.IntTensor,
+    codebooks: torch.Tensor,
+    scales: torch.Tensor,
+    bias: Optional[torch.Tensor],
+) -> torch.Tensor:
+    return forward_pass_quantized_linear(
+        grad_output.contiguous(),
+        codes.transpose(0, 1).contiguous(),
+        codebooks.transpose(2, 3).contiguous(),
+        scales.transpose(0, 1).transpose(2, 3).contiguous(),
+        None,
+    )
+
+
+class QuantizedMatmul(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx: torch.Any,
+        input: torch.Tensor,
+        codes: torch.IntTensor,
+        codebooks: torch.Tensor,
+        scales: torch.Tensor,
+        bias: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        ctx.save_for_backward(
+            input,
+            codes,
+            codebooks,
+            scales,
+            bias,
+        )
+        return forward_pass_quantized_linear(
+            input=input,
+            codes=codes,
+            codebooks=codebooks,
+            scales=scales,
+            bias=bias,
+        )
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> torch.Tensor:
+        input, codes, codebooks, scales, bias = ctx.saved_tensors
+        return (
+            backward_pass_quantized_linear(
+                grad_output=grad_output,
+                codes=codes,
+                codebooks=codebooks,
+                scales=scales,
+                bias=bias,
+            ),
+            None,
+            None,
+            None,
+            None,
+        )

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -3,6 +3,7 @@ from typing import Optional
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
 from aqlm.utils import _dequantize_weight, unpack_int_data
 
 
@@ -14,8 +15,8 @@ def forward_pass_quantized_linear(
     bias: Optional[torch.Tensor],
 ) -> torch.Tensor:
     num_codebooks, codebook_size, out_group_size, in_group_size = codebooks.shape
-    match (input.is_cuda, num_codebooks, codebook_size, out_group_size, in_group_size):
-        case (True, 1, 65536, 1, 8):
+    match (input.device.type, num_codebooks, codebook_size, out_group_size, in_group_size):
+        case ("cuda", 1, 65536, 1, 8):
             from .cuda_kernel import CUDA_FOLDER
 
             assert (
@@ -24,7 +25,7 @@ def forward_pass_quantized_linear(
             return torch.ops.aqlm_cuda_kernel.code1x16_matmat(input, codes, codebooks, scales) + (
                 bias if bias is not None else 0
             )
-        case (True, 2, 256, 1, 8):
+        case ("cuda", 2, 256, 1, 8):
             from .cuda_kernel import CUDA_FOLDER
 
             assert (
@@ -33,11 +34,11 @@ def forward_pass_quantized_linear(
             return torch.ops.aqlm_cuda_kernel.code2x8_matmat(input, codes, codebooks, scales) + (
                 bias if bias is not None else 0
             )
-        case (True, _, _, _, _):
+        case ("cuda", _, _, 1, _):
             from .triton_kernel import triton_matmul
 
             return triton_matmul(input, codes, codebooks, scales, bias)
-        case (False, _, 256, 1, _):
+        case ("cpu", _, 256, 1, _):
             from .numba_kernel import numba_gemm_lut
 
             return numba_gemm_lut(input, codes, codebooks, scales, bias)

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -4,7 +4,6 @@ from typing import Callable, Optional
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
 from aqlm.utils import _dequantize_weight, unpack_int_data
 
 _OPTIMIZE_FOR_TRAINING = False

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Callable, Optional
 
 import torch
 import torch.nn as nn
@@ -7,100 +7,57 @@ import torch.nn.functional as F
 from aqlm.utils import _dequantize_weight, unpack_int_data
 
 
-def forward_pass_quantized_linear(
-    input: torch.Tensor,
-    codes: torch.IntTensor,
+def get_forward_pass_kernel(
     codebooks: torch.Tensor,
-    scales: torch.Tensor,
-    bias: Optional[torch.Tensor],
-) -> torch.Tensor:
+) -> Callable[[torch.Tensor, torch.IntTensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]], torch.Tensor]:
     num_codebooks, codebook_size, out_group_size, in_group_size = codebooks.shape
-    match (input.device.type, num_codebooks, codebook_size, out_group_size, in_group_size):
+    match (codebooks.device.type, num_codebooks, codebook_size, out_group_size, in_group_size):
         case ("cuda", 1, 65536, 1, 8):
             from .cuda_kernel import CUDA_FOLDER
 
             assert (
-                input.dtype == torch.float16
-            ), f"please load the model with `torch_dtype=torch.float16`, as {input.dtype} is not supported on GPU yet"
-            return torch.ops.aqlm_cuda_kernel.code1x16_matmat(input, codes, codebooks, scales, bias)
+                codebooks.dtype == torch.float16
+            ), f"please load the model with `torch_dtype=torch.float16`, as {codebooks.dtype} is not supported on GPU yet"
+            return torch.ops.aqlm_cuda_kernel.code1x16_matmat
         case ("cuda", 2, 256, 1, 8):
             from .cuda_kernel import CUDA_FOLDER
 
             assert (
-                input.dtype == torch.float16
-            ), f"please load the model with `torch_dtype=torch.float16`, as {input.dtype} is not supported on GPU yet"
-            return torch.ops.aqlm_cuda_kernel.code2x8_matmat(input, codes, codebooks, scales, bias)
+                codebooks.dtype == torch.float16
+            ), f"please load the model with `torch_dtype=torch.float16`, as {codebooks.dtype} is not supported on GPU yet"
+            return torch.ops.aqlm_cuda_kernel.code2x8_matmat
         case ("cuda", _, _, 1, _):
             from .triton_kernel import triton_matmul
 
-            return triton_matmul(input, codes, codebooks, scales, bias)
+            return triton_matmul
         case ("cpu", _, 256, 1, _):
             from .numba_kernel import numba_gemm_lut
 
-            return numba_gemm_lut(input, codes, codebooks, scales, bias)
+            return numba_gemm_lut
         case _:
-            dequantized_weight = _dequantize_weight(
-                unpack_int_data(codes, codebooks.shape[1].bit_length() - 1),
-                codebooks,
-                scales,
-            )
-            return F.linear(input, dequantized_weight, bias)
+            from .dequantization import dequantize_gemm
+
+            return dequantize_gemm
 
 
-def backward_pass_quantized_linear(
-    grad_output: torch.Tensor,
-    codes: torch.IntTensor,
+def get_backward_pass_kernel(
     codebooks: torch.Tensor,
-    scales: torch.Tensor,
-    bias: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    return forward_pass_quantized_linear(
-        grad_output.contiguous(),
-        codes.transpose(0, 1).contiguous(),
-        codebooks.transpose(2, 3).contiguous(),
-        scales.transpose(0, 1).transpose(2, 3).contiguous(),
-        None,
-    )
+    forward_pass_kernel = get_forward_pass_kernel(codebooks=codebooks)
 
-
-class QuantizedMatmul(torch.autograd.Function):
-    @staticmethod
-    def forward(
-        ctx: torch.Any,
-        input: torch.Tensor,
-        codes: torch.IntTensor,
-        codebooks: torch.Tensor,
-        scales: torch.Tensor,
+    def _backward_pass_kernel(
+        grad_output: torch.Tensor,  #  [..., in_features]
+        codes: torch.IntTensor,  #  [num_out_groups, num_in_groups, num_codebooks]
+        codebooks: torch.Tensor,  #  [num_codebooks, codebook_size, out_group_size, in_group_size]
+        scales: torch.Tensor,  #  [num_out_groups, 1, 1, 1]
         bias: Optional[torch.Tensor],
     ) -> torch.Tensor:
-        ctx.save_for_backward(
-            input,
-            codes,
-            codebooks,
-            scales,
-            bias,
-        )
-        return forward_pass_quantized_linear(
-            input=input,
-            codes=codes,
-            codebooks=codebooks,
-            scales=scales,
-            bias=bias,
+        return forward_pass_kernel(
+            grad_output.contiguous(),
+            codes.transpose(0, 1).contiguous(),
+            codebooks.transpose(2, 3).contiguous(),
+            scales.transpose(0, 1).transpose(2, 3).contiguous(),
+            None,
         )
 
-    @staticmethod
-    def backward(ctx, grad_output: torch.Tensor) -> torch.Tensor:
-        input, codes, codebooks, scales, bias = ctx.saved_tensors
-        return (
-            backward_pass_quantized_linear(
-                grad_output=grad_output,
-                codes=codes,
-                codebooks=codebooks,
-                scales=scales,
-                bias=bias,
-            ),
-            None,
-            None,
-            None,
-            None,
-        )
+    return _backward_pass_kernel

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -12,6 +12,7 @@ _OPTIMIZE_FOR_TRAINING = False
 
 @contextmanager
 def optimize_for_training():
+    """Use this context manager during model initialization (e.g. `.from_pretrained(...)`) to select inference kernels optimized for larger batch sizes"""
     global _OPTIMIZE_FOR_TRAINING
     _OPTIMIZE_FOR_TRAINING = True
     try:

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -22,18 +22,14 @@ def forward_pass_quantized_linear(
             assert (
                 input.dtype == torch.float16
             ), f"please load the model with `torch_dtype=torch.float16`, as {input.dtype} is not supported on GPU yet"
-            return torch.ops.aqlm_cuda_kernel.code1x16_matmat(input, codes, codebooks, scales) + (
-                bias if bias is not None else 0
-            )
+            return torch.ops.aqlm_cuda_kernel.code1x16_matmat(input, codes, codebooks, scales, bias)
         case ("cuda", 2, 256, 1, 8):
             from .cuda_kernel import CUDA_FOLDER
 
             assert (
                 input.dtype == torch.float16
             ), f"please load the model with `torch_dtype=torch.float16`, as {input.dtype} is not supported on GPU yet"
-            return torch.ops.aqlm_cuda_kernel.code2x8_matmat(input, codes, codebooks, scales) + (
-                bias if bias is not None else 0
-            )
+            return torch.ops.aqlm_cuda_kernel.code2x8_matmat(input, codes, codebooks, scales, bias)
         case ("cuda", _, _, 1, _):
             from .triton_kernel import triton_matmul
 

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -59,7 +59,9 @@ def get_backward_pass_kernel(
     codebooks: torch.Tensor,
     optimize_for_training: bool,
 ) -> torch.Tensor:
-    forward_pass_kernel = get_forward_pass_kernel(codebooks=codebooks, optimize_for_training=optimize_for_training)
+    forward_pass_kernel = get_forward_pass_kernel(
+        codebooks=codebooks.transpose(2, 3), optimize_for_training=optimize_for_training
+    )
 
     def _backward_pass_kernel(
         grad_output: torch.Tensor,  #  [..., in_features]

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -49,7 +49,7 @@ def get_forward_pass_kernel(
             from .numba_kernel import numba_gemm_lut
 
             return numba_gemm_lut
-        case (True, *_):
+        case _:
             from .dequantization import dequantize_gemm
 
             return dequantize_gemm

--- a/inference_lib/src/aqlm/inference_kernels/triton_kernel.py
+++ b/inference_lib/src/aqlm/inference_kernels/triton_kernel.py
@@ -22,6 +22,7 @@ from torch.autograd import Function
         "num_input_groups",
         "num_input_groups_next_power_of_2",
         "compute_in_fp32",
+        "has_output_scale",
         "has_bias",
     ],
 )
@@ -42,11 +43,12 @@ def _aqlm_gemv_simple(
     num_input_groups: tl.constexpr,
     num_input_groups_next_power_of_2: tl.constexpr,
     compute_in_fp32: tl.constexpr,
+    has_output_scale: tl.constexpr,
     has_bias: tl.constexpr,
     UNUSED: tl.constexpr,
 ):
     # variables ending with "_i" mean "for i-th output unit"
-    pid = tl.program_id(axis=0)  # [0, 1, ... {out_features-1}]
+    pid = tl.program_id(axis=0)  # [0, 1, ... {num_out_groups-1}]
 
     # Stage 1: load input data
     input_vec = tl.load(
@@ -60,6 +62,7 @@ def _aqlm_gemv_simple(
     #     input_vec = tl.load(input_vec_ptr + tl.arange(0, in_features))  # [in_features]
     #     input_vec = tl.view(input_vec, [num_input_groups, 1, in_group_size])
     #     , but this does not work because tl.view may reorder elements arbitrarily; see its docstring
+    dtype = input_vec.dtype
 
     # Stage 2: load integer codes for the active row
     # [in_features // in_group_size, num_codebooks]
@@ -101,65 +104,28 @@ def _aqlm_gemv_simple(
         input_vec = input_vec.to(tl.float32)
     # ^-- [in_features // in_group_size, num_codebooks, out_group_size, in_group_size]
 
+    output_i = weights_i * input_vec  #  [in_features // in_group_size, num_codebooks, out_group_size, in_group_size]
+
     if out_group_size == 1:
-        scale = tl.load(scales_ptr + pid).to(weights_i.dtype)  # scalar
-        output_i = tl.sum(weights_i * input_vec) * scale
-        if has_bias:
-            output_i += tl.load(bias_ptr + pid).to(weights_i.dtype)
-        tl.store(output_vec_ptr + pid, output_i.to(input_vec.dtype))
+        output_i = tl.sum(output_i)  #  []
     else:
-        output_i = tl.sum(tl.sum(weights_i, axis=2) * input_vec, axis=0)  # [out_group_size]
-        output_i *= tl.load(scales_ptr + pid).to(weights_i.dtype)
-        if has_bias:
-            output_i += tl.load(bias_ptr + pid).to(weights_i.dtype)
-        tl.store(output_vec_ptr + pid * out_group_size + tl.arange(0, out_group_size), output_i.to(input_vec.dtype))
+        output_i = tl.sum(output_i, axis=1)  #  [in_features // in_group_size, out_group_size, in_group_size]
+        output_i = tl.sum(output_i, axis=2)  #  [in_features // in_group_size, out_group_size]
+        output_i = tl.sum(output_i, axis=0)  #  [out_group_size]
+
+    if has_output_scale:
+        output_i *= tl.load(scales_ptr + pid).to(weights_i.dtype)  # scalar
+    if has_bias:
+        output_i += tl.load(bias_ptr + pid).to(weights_i.dtype)
+
+    if out_group_size == 1:
+        tl.store(output_vec_ptr + pid, output_i.to(dtype))
+    else:
+        tl.store(output_vec_ptr + pid * out_group_size + tl.arange(0, out_group_size), output_i.to(dtype))
 
 
 def next_power_of_2(x):
     return 1 if x == 0 else 2 ** (x - 1).bit_length()
-
-
-def aqlm_gemv_simple(
-    input_vec: torch.Tensor,
-    codes_i16: torch.ShortTensor,
-    codebooks: torch.Tensor,
-    scales: torch.Tensor,
-    bias: Optional[torch.Tensor],
-    compute_in_fp32: bool = True,
-):
-    device, dtype = codebooks.device, codebooks.dtype
-    num_codebooks, codebook_size, out_group_size, in_group_size = codebooks.shape
-    in_features = input_vec.shape[1]
-    out_features = codes_i16.shape[0] * out_group_size
-    num_input_groups = codes_i16.shape[1]
-    assert input_vec.ndim == 2 and input_vec.shape[0] == 1, "do reshape; now!"
-    assert scales.shape == (out_features // out_group_size, 1, 1, 1)
-    assert in_features % in_group_size == 0
-    assert codebooks.shape[1] < 2**32
-
-    output_vec = torch.empty(1, out_features, device=device, dtype=dtype)
-    # 1D launch kernel where each block computes output unit
-    grid = lambda META: (out_features // out_group_size,)
-    _aqlm_gemv_simple[grid](
-        input_vec,
-        output_vec,
-        codes_i16,
-        codebooks,
-        scales,
-        bias,
-        in_features,
-        out_features,
-        num_codebooks,
-        codebook_size,
-        out_group_size,
-        in_group_size,
-        num_input_groups,
-        next_power_of_2(num_input_groups),
-        compute_in_fp32,
-        bias is not None,
-    )
-
-    return output_vec
 
 
 def aqlm_gemm_stupid(
@@ -176,9 +142,19 @@ def aqlm_gemm_stupid(
     out_features = codes_i16.shape[0] * out_group_size
     num_input_groups = codes_i16.shape[1]
     assert input.ndim == 2
-    assert scales.shape == (out_features // out_group_size, 1, 1, 1)
     assert in_features % in_group_size == 0
     assert codebooks.shape[1] < 2**32
+
+    if scales.shape == (out_features // out_group_size, 1, 1, 1):
+        has_output_scales = True
+    elif scales.shape == (1, in_features // in_group_size, 1, 1) and in_group_size == 1:
+        has_output_scales = False
+        input *= scales.squeeze()
+    else:
+        raise NotImplementedError(f"Can't do Triton AQLM matmul with scales of shape {scales.shape}")
+
+    if not input.is_contiguous():
+        raise Exception("AAAA")
 
     output = torch.empty(input.shape[0], out_features, device=device, dtype=dtype)
     for i in range(input.shape[0]):
@@ -200,6 +176,7 @@ def aqlm_gemm_stupid(
             num_input_groups,
             next_power_of_2(num_input_groups),
             compute_in_fp32,
+            has_output_scales,
             bias is not None,
         )
 
@@ -217,21 +194,11 @@ def triton_matmul(
     input_shape = input.shape
     input = input.reshape(-1, input_shape[-1])
 
-    if input.shape[0] == 1:
-        return aqlm_gemv_simple(
-            input,
-            codes,
-            codebooks,
-            scales,
-            bias,
-            compute_in_fp32,
-        ).reshape(input_shape[:-1] + (-1,))
-    else:
-        return aqlm_gemm_stupid(
-            input,
-            codes,
-            codebooks,
-            scales,
-            bias,
-            compute_in_fp32,
-        ).reshape(input_shape[:-1] + (-1,))
+    return aqlm_gemm_stupid(
+        input,
+        codes,
+        codebooks,
+        scales,
+        bias,
+        compute_in_fp32,
+    ).reshape(input_shape[:-1] + (-1,))

--- a/inference_lib/src/aqlm/inference_kernels/triton_kernel.py
+++ b/inference_lib/src/aqlm/inference_kernels/triton_kernel.py
@@ -1,3 +1,4 @@
+import math
 from typing import Optional
 
 import torch
@@ -125,7 +126,7 @@ def _aqlm_gemv_simple(
 
 
 def next_power_of_2(x):
-    return 1 if x == 0 else 2 ** (x - 1).bit_length()
+    return 1 if x == 0 else 2 ** math.ceil(math.log2(x))
 
 
 def aqlm_gemm_stupid(


### PR DESCRIPTION
This PR aims to:
 * Add support for backward passes enabling [Adapter Training](https://huggingface.co/docs/peft/index).
 * Optimize kernel selection to:
   *  Allow to select optimal kernels for training/inference.
   * Select kernels once to not run selection on each forward pass.