### PR TITLE
Dynamic kernel selection for traning/inference

### DIFF
--- a/inference_lib/setup.cfg
+++ b/inference_lib/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aqlm
-version = 1.1.0dev
+version = 1.1.0
 author = AQLM paper authors
 author_email = vahe527887@yandex.ru
 description = Efficiently run models quantized with AQLM

--- a/inference_lib/setup.cfg
+++ b/inference_lib/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aqlm
-version = 1.0.3
+version = 1.1.0dev
 author = AQLM paper authors
 author_email = vahe527887@yandex.ru
 description = Efficiently run models quantized with AQLM

--- a/inference_lib/src/aqlm/inference.py
+++ b/inference_lib/src/aqlm/inference.py
@@ -1,4 +1,5 @@
 """ Core mathematics for Additive Quantization (AQ): initialization, reconstruction and beam search"""
+import math
 from typing import Optional
 
 import torch
@@ -91,7 +92,7 @@ class QuantizedLinear(nn.Module):
             get_backward_pass_kernel(self.codebooks, True),
         )
 
-        self.use_gemv_rule = lambda input: sum(input.shape[:-1]) <= 32
+        self.use_gemv_rule = lambda input: math.prod(input.shape[:-1]) <= 32
 
 
 def _get_autograd_matmul_op(forward_pass_kernel, backward_pass_kernel):

--- a/inference_lib/src/aqlm/inference.py
+++ b/inference_lib/src/aqlm/inference.py
@@ -60,15 +60,19 @@ class QuantizedLinear(nn.Module):
         else:
             self.register_parameter("bias", None)
 
-        # MATMUL_OP
-        self.optimize_for_training: bool = aqlm.inference_kernels.kernel_selector._OPTIMIZE_FOR_TRAINING
-        self.matmul_op = None
+        # MATMUL_OPS
+        self.gemv_op = None
+        self.gemm_op = None
+        self.use_gemv_rule = None
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        if self.matmul_op is None:
+        if self.gemv_op is None:
             self.prepare_matmul_op(input)
-
-        return self.matmul_op.apply(input, self.codes, self.codebooks, self.scales, self.bias)
+            
+        if self.use_gemv_rule(input):
+            return self.gemv_op.apply(input, self.codes, self.codebooks, self.scales, self.bias)
+        else:
+            return self.gemm_op.apply(input, self.codes, self.codebooks, self.scales, self.bias)
 
     def prepare_matmul_op(self, input: torch.Tensor):
         if (
@@ -78,49 +82,60 @@ class QuantizedLinear(nn.Module):
         ):
             self.codes.data = torch.permute(self.codes.data, (1, 0, 2)).contiguous()  #  TODO: fix this thing
 
-        forward_pass_kernel = get_forward_pass_kernel(self.codebooks, self.optimize_for_training)
-        backward_pass_kernel = get_backward_pass_kernel(self.codebooks, self.optimize_for_training)
+        self.gemv_op = _get_autograd_matmul_op(
+            get_forward_pass_kernel(self.codebooks, False),
+            get_backward_pass_kernel(self.codebooks, False),
+        )
 
-        class _QuantizedMatmul(torch.autograd.Function):
-            @staticmethod
-            def forward(
-                ctx: torch.Any,
-                input: torch.Tensor,
-                codes: torch.IntTensor,
-                codebooks: torch.Tensor,
-                scales: torch.Tensor,
-                bias: Optional[torch.Tensor],
-            ) -> torch.Tensor:
-                ctx.save_for_backward(
-                    input,
+        self.gemm_op = _get_autograd_matmul_op(
+            get_forward_pass_kernel(self.codebooks, True),
+            get_backward_pass_kernel(self.codebooks, True),
+        )
+        
+        self.use_gemv_rule = lambda input: sum(input.shape[:-1]) < 100
+
+
+def _get_autograd_matmul_op(forward_pass_kernel, backward_pass_kernel):
+    class _QuantizedMatmul(torch.autograd.Function):
+        @staticmethod
+        def forward(
+            ctx: torch.Any,
+            input: torch.Tensor,
+            codes: torch.IntTensor,
+            codebooks: torch.Tensor,
+            scales: torch.Tensor,
+            bias: Optional[torch.Tensor],
+        ) -> torch.Tensor:
+            ctx.save_for_backward(
+                input,
+                codes,
+                codebooks,
+                scales,
+                bias,
+            )
+            return forward_pass_kernel(
+                input,
+                codes,
+                codebooks,
+                scales,
+                bias,
+            )
+
+        @staticmethod
+        def backward(ctx, grad_output: torch.Tensor) -> torch.Tensor:
+            input, codes, codebooks, scales, bias = ctx.saved_tensors
+            return (
+                backward_pass_kernel(
+                    grad_output,
                     codes,
                     codebooks,
                     scales,
                     bias,
-                )
-                return forward_pass_kernel(
-                    input,
-                    codes,
-                    codebooks,
-                    scales,
-                    bias,
-                )
+                ),
+                None,
+                None,
+                None,
+                None,
+            )
 
-            @staticmethod
-            def backward(ctx, grad_output: torch.Tensor) -> torch.Tensor:
-                input, codes, codebooks, scales, bias = ctx.saved_tensors
-                return (
-                    backward_pass_kernel(
-                        grad_output,
-                        codes,
-                        codebooks,
-                        scales,
-                        bias,
-                    ),
-                    None,
-                    None,
-                    None,
-                    None,
-                )
-
-        self.matmul_op = _QuantizedMatmul
+    return _QuantizedMatmul

--- a/inference_lib/src/aqlm/inference.py
+++ b/inference_lib/src/aqlm/inference.py
@@ -1,7 +1,6 @@
 """ Core mathematics for Additive Quantization (AQ): initialization, reconstruction and beam search"""
 from typing import Optional
 
-import aqlm
 import torch
 import torch.nn as nn
 from aqlm.inference_kernels import get_backward_pass_kernel, get_forward_pass_kernel
@@ -68,7 +67,7 @@ class QuantizedLinear(nn.Module):
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         if self.gemv_op is None:
             self.prepare_matmul_op(input)
-            
+
         if self.use_gemv_rule(input):
             return self.gemv_op.apply(input, self.codes, self.codebooks, self.scales, self.bias)
         else:
@@ -91,8 +90,8 @@ class QuantizedLinear(nn.Module):
             get_forward_pass_kernel(self.codebooks, True),
             get_backward_pass_kernel(self.codebooks, True),
         )
-        
-        self.use_gemv_rule = lambda input: sum(input.shape[:-1]) < 100
+
+        self.use_gemv_rule = lambda input: sum(input.shape[:-1]) <= 32
 
 
 def _get_autograd_matmul_op(forward_pass_kernel, backward_pass_kernel):

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -55,7 +55,7 @@ def get_forward_pass_kernel(
         from .triton_kernel import triton_matmul
 
         return triton_matmul
-    elif (optimize_for_training, codebooks.device.type, codebook_size, out_group_size) == (False, "cpu", 256, 1):
+    elif (codebooks.device.type, codebook_size, out_group_size) == ("cpu", 256, 1):
         from .numba_kernel import numba_gemm_lut
 
         return numba_gemm_lut

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -1,16 +1,17 @@
-import logging
+import warnings
 from contextlib import contextmanager
 from typing import Callable, Optional
 
 import torch
 
-logger = logging.getLogger(__name__)
-
 
 @contextmanager
 def optimize_for_training():
-    """Use this context manager during model initialization (e.g. `.from_pretrained(...)`) to select inference kernels optimized for larger batch sizes"""
-    logger.warning("`optimize_for_training` is deprecated. The optimization now happens automatically at runtime.")
+    """
+    WARNING: `optimize_for_training` is deprecated. The optimization now happens automatically at runtime.
+    OBSOLETE: Use this context manager during model initialization (e.g. `.from_pretrained(...)`) to select inference kernels optimized for larger batch sizes
+    """
+    warnings.warn("`optimize_for_training` is deprecated. The optimization now happens automatically at runtime.")
     try:
         yield
     finally:

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -1,23 +1,20 @@
+import logging
 from contextlib import contextmanager
 from typing import Callable, Optional
 
 import torch
-import torch.nn as nn
-import torch.nn.functional as F
-from aqlm.utils import _dequantize_weight, unpack_int_data
 
-_OPTIMIZE_FOR_TRAINING = False
+logger = logging.getLogger(__name__)
 
 
 @contextmanager
 def optimize_for_training():
     """Use this context manager during model initialization (e.g. `.from_pretrained(...)`) to select inference kernels optimized for larger batch sizes"""
-    global _OPTIMIZE_FOR_TRAINING
-    _OPTIMIZE_FOR_TRAINING = True
+    logger.warning("`optimize_for_training` is deprecated. The optimization now happens automatically at runtime.")
     try:
         yield
     finally:
-        _OPTIMIZE_FOR_TRAINING = False
+        return
 
 
 def get_forward_pass_kernel(

--- a/inference_lib/src/aqlm/inference_kernels/numba_kernel.py
+++ b/inference_lib/src/aqlm/inference_kernels/numba_kernel.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 
 import numba
@@ -5,6 +6,9 @@ import numpy as np
 import torch
 
 COMPILED_KERNELS = {}
+
+
+logger = logging.getLogger(__name__)
 
 
 def numba_gemm_lut(
@@ -33,7 +37,7 @@ def numba_gemm_lut(
 
     kernel_key = (in_group_size, out_features, in_features, num_codebooks)
     if kernel_key not in COMPILED_KERNELS:
-        print(f"Compiling AQLM numba kernel with parameters: {kernel_key=}")
+        logger.info(f"Compiling AQLM numba kernel with parameters: {kernel_key=}")
 
         @numba.njit(parallel=True)
         def numba_gemv_lut_(x, codebooks, codes_alt, scales):

--- a/inference_lib/src/aqlm/inference_kernels/numba_kernel.py
+++ b/inference_lib/src/aqlm/inference_kernels/numba_kernel.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Optional
 
 import numba
@@ -6,9 +5,6 @@ import numpy as np
 import torch
 
 COMPILED_KERNELS = {}
-
-
-logger = logging.getLogger(__name__)
 
 
 def numba_gemm_lut(
@@ -37,7 +33,6 @@ def numba_gemm_lut(
 
     kernel_key = (in_group_size, out_features, in_features, num_codebooks)
     if kernel_key not in COMPILED_KERNELS:
-        logger.info(f"Compiling AQLM numba kernel with parameters: {kernel_key=}")
 
         @numba.njit(parallel=True)
         def numba_gemv_lut_(x, codebooks, codes_alt, scales):


### PR DESCRIPTION
Right now, `aqlm` requires one to load models with
```python
with aqlm.optimize_for_training():
    model = AutoModelForCausalLM.from_pretrained(...)
```
to use kernels optimized for larger batch sizes. It doesn't need to be that way since it's pretty easy to tell which kernels should be used by just looking at the input.

This PR does that.