### PR TITLE
Native support for Bfloat16 for 1x16 and 2x8 CUDA kernels

### DIFF
--- a/inference_lib/setup.cfg
+++ b/inference_lib/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aqlm
-version = 1.1.0
+version = 1.1.1dev
 author = AQLM paper authors
 author_email = vahe527887@yandex.ru
 description = Efficiently run models quantized with AQLM

--- a/inference_lib/setup.cfg
+++ b/inference_lib/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aqlm
-version = 1.1.1dev
+version = 1.1.1
 author = AQLM paper authors
 author_email = vahe527887@yandex.ru
 description = Efficiently run models quantized with AQLM

--- a/inference_lib/setup.cfg
+++ b/inference_lib/setup.cfg
@@ -33,7 +33,7 @@ packages = find:
 include_package_data = True
 python_requires = >=3.8
 install_requires =
-    torch>=2.1.1
+    torch>=2.2.0
     transformers>=4.38.0
     accelerate>=0.27.0
 [options.extras_require]

--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
@@ -13,7 +13,11 @@ inline bool check_use_bfloat16(const torch::Tensor& input) {
   } else {
     throw c10::NotImplementedError(
       {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},
-      c10::str("only float16 and bfloat16 are supported. Got ", dtype.name())
+      c10::str(
+        "AQLM CUDA kernels only support float16 and bfloat16. Got ",
+        dtype.name(),
+        ". Please specify the correct `torch_dtype` when loading the model."
+      )
     );
   }
 }

--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
@@ -1,6 +1,22 @@
 #include <torch/all.h>
 #include <torch/python.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/util/Exception.h>
+
+
+inline bool check_use_bfloat16(const torch::Tensor& input) {
+  auto dtype = input.dtype();
+  if (dtype == at::kHalf) {
+    return false;
+  } else if (dtype == at::kBFloat16) {
+    return true;
+  } else {
+    throw c10::NotImplementedError(
+      {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},
+      c10::str("only float16 and bfloat16 are supported. Got ", dtype.name())
+    );
+  }
+}
 
 void code1x16_matvec_cuda(
   const void* A,
@@ -8,7 +24,8 @@ void code1x16_matvec_cuda(
         void* C,
   const void* codebook,
   int prob_m,
-  int prob_k
+  int prob_k,
+  bool use_bfloat16
 );
 
 void code2x8_matvec_cuda(
@@ -17,14 +34,16 @@ void code2x8_matvec_cuda(
         void* C,
   const void* codebook,
   int prob_m,
-  int prob_k
+  int prob_k,
+  bool use_bfloat16
 );
 
 void code1x16_matvec(
   const torch::Tensor& A,
   const torch::Tensor& B,
         torch::Tensor& C,
-  const torch::Tensor& codebook
+  const torch::Tensor& codebook,
+  const bool use_bfloat16
 ) {
   const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
   int prob_m = C.size(0);
@@ -35,7 +54,8 @@ void code1x16_matvec(
     C.data_ptr(),
     codebook.data_ptr(),
     prob_m,
-    prob_k
+    prob_k,
+    use_bfloat16
   );
 }
 
@@ -46,6 +66,7 @@ torch::Tensor code1x16_matmat(
   const torch::Tensor& scales,
   const std::optional<torch::Tensor>& bias
 ) {
+  bool use_bfloat16 = check_use_bfloat16(input);
   auto input_sizes = input.sizes();
   auto out_features = codes.size(0) * codebooks.size(2);
   auto flat_input = input.reshape({-1, input.size(-1)});
@@ -62,7 +83,8 @@ torch::Tensor code1x16_matmat(
       codes.squeeze(2),
       input_vec,
       output_vec,
-      codebooks
+      codebooks,
+      use_bfloat16
     );
   }
   flat_output *= scales.flatten().unsqueeze(0);
@@ -81,7 +103,8 @@ void code2x8_matvec(
   const torch::Tensor& A,
   const torch::Tensor& B,
         torch::Tensor& C,
-  const torch::Tensor& codebook
+  const torch::Tensor& codebook,
+  bool use_bfloat16
 ) {
   const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
   int prob_m = C.size(0);
@@ -92,7 +115,8 @@ void code2x8_matvec(
     C.data_ptr(),
     codebook.data_ptr(),
     prob_m,
-    prob_k
+    prob_k,
+    use_bfloat16
   );
 }
 
@@ -103,6 +127,7 @@ torch::Tensor code2x8_matmat(
   const torch::Tensor& scales,
   const std::optional<torch::Tensor>& bias
 ) {
+  bool use_bfloat16 = check_use_bfloat16(input);
   auto input_sizes = input.sizes();
   auto out_features = codes.size(0) * codebooks.size(2);
   auto flat_input = input.reshape({-1, input.size(-1)});
@@ -119,7 +144,8 @@ torch::Tensor code2x8_matmat(
       codes.squeeze(2),
       input_vec,
       output_vec,
-      codebooks
+      codebooks,
+      use_bfloat16
     );
   }
   flat_output *= scales.flatten().unsqueeze(0);

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -34,9 +34,6 @@ def get_forward_pass_kernel(
     ):
         from .cuda_kernel import CUDA_FOLDER
 
-        assert (
-            codebooks.dtype == torch.float16
-        ), f"please load the model with `torch_dtype=torch.float16`, as {codebooks.dtype} is not supported on GPU yet"
         return torch.ops.aqlm.code1x16_matmat
     elif (
         optimize_for_training,
@@ -48,9 +45,6 @@ def get_forward_pass_kernel(
     ) == (False, "cuda", 2, 256, 1, 8):
         from .cuda_kernel import CUDA_FOLDER
 
-        assert (
-            codebooks.dtype == torch.float16
-        ), f"please load the model with `torch_dtype=torch.float16`, as {codebooks.dtype} is not supported on GPU yet"
         return torch.ops.aqlm.code2x8_matmat
     elif (optimize_for_training, codebooks.device.type, out_group_size) == (False, "cuda", 1):
         from .triton_kernel import triton_matmul


### PR DESCRIPTION
This PR should allow one to run 1x16 AQLM in `bfloat16`.