### PR TITLE
Remove post flattening CUDA `clone()`s, for 2% speedup in a 1x16 7B llama2

### DIFF
--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
@@ -73,7 +73,7 @@ torch::Tensor code1x16_matmat(
   auto output_sizes = input_sizes.vec();
   output_sizes.pop_back();
   output_sizes.push_back(-1);
-  auto output = flat_output.reshape(output_sizes).clone();
+  auto output = flat_output.reshape(output_sizes);
   return output;
 }
 
@@ -130,7 +130,7 @@ torch::Tensor code2x8_matmat(
   auto output_sizes = input_sizes.vec();
   output_sizes.pop_back();
   output_sizes.push_back(-1);
-  auto output = flat_output.reshape(output_sizes).clone();
+  auto output = flat_output.reshape(output_sizes);
   return output;
 }
 


### PR DESCRIPTION
I found these clones while porting the CUDA kernels to vLLM.  I couldn't see what they were for (avoid memory fragmentation?) but got a 2% speed improvement on your llama2 7B 1x16 model without them.