### PR TITLE
`__CUDA_ARCH__<=8.0`  compilation error fix.

### DIFF
--- a/inference_lib/setup.cfg
+++ b/inference_lib/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aqlm
-version = 1.1.2dev
+version = 1.1.2
 author = AQLM paper authors
 author_email = vahe527887@yandex.ru
 description = Efficiently run models quantized with AQLM

--- a/inference_lib/setup.cfg
+++ b/inference_lib/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aqlm
-version = 1.1.1
+version = 1.1.2dev
 author = AQLM paper authors
 author_email = vahe527887@yandex.ru
 description = Efficiently run models quantized with AQLM

--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cu
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cu
@@ -195,12 +195,9 @@ void  code1x16_matvec_cuda(
   int prob_k,
   bool use_bfloat16
 ) {
-  int device;
-  cudaGetDevice(&device);
-
-  struct cudaDeviceProp props;
-  cudaGetDeviceProperties(&props, device);
-  if (props.major < 8 && use_bfloat16) {
+  int cc_major;
+  cudaDeviceGetAttribute(&cc_major, cudaDevAttrComputeCapabilityMajor, 0);
+  if (cc_major < 8 && use_bfloat16) {
     throw c10::TypeError(
       {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},
       c10::str(
@@ -251,12 +248,9 @@ void  code2x8_matvec_cuda(
   int prob_k,
   bool use_bfloat16
 ) {
-  int device;
-  cudaGetDevice(&device);
-
-  struct cudaDeviceProp props;
-  cudaGetDeviceProperties(&props, device);
-  if (props.major < 8 && use_bfloat16) {
+  int cc_major;
+  cudaDeviceGetAttribute(&cc_major, cudaDevAttrComputeCapabilityMajor, 0);
+  if (cc_major < 8 && use_bfloat16) {
     throw c10::TypeError(
       {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},
       c10::str(

--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cu
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cu
@@ -195,16 +195,19 @@ void  code1x16_matvec_cuda(
   int prob_k,
   bool use_bfloat16
 ) {
-  #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800)
-  if (use_bfloat16) {
+  int device;
+  cudaGetDevice(&device);
+
+  struct cudaDeviceProp props;
+  cudaGetDeviceProperties(&props, device);
+  if (props.major < 8 && use_bfloat16) {
     throw c10::TypeError(
       {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},
       c10::str(
         "You're trying to run AQLM with bfloat16 on a GPU with low compute capability. Use torch.float16 instead."
       )
     );
-  } 
-  #endif
+  }
 
   int sms;
   cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);
@@ -248,16 +251,19 @@ void  code2x8_matvec_cuda(
   int prob_k,
   bool use_bfloat16
 ) {
-  #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800)
-  if (use_bfloat16) {
+  int device;
+  cudaGetDevice(&device);
+
+  struct cudaDeviceProp props;
+  cudaGetDeviceProperties(&props, device);
+  if (props.major < 8 && use_bfloat16) {
     throw c10::TypeError(
       {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},
       c10::str(
         "You're trying to run AQLM with bfloat16 on a GPU with low compute capability. Use torch.float16 instead."
       )
     );
-  } 
-  #endif
+  }
 
   int sms;
   cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);

--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cu
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cu
@@ -51,7 +51,7 @@ __global__ void Code1x16MatVec(
           : "l"((void*) &codebook[enc[i]])
         );
         if constexpr (use_bfloat16) {
-        #if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800) || defined(_NVHPC_CUDA))
+        #if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800)
           nv_bfloat162* a = reinterpret_cast<nv_bfloat162*>(&dec);
           nv_bfloat162* b = reinterpret_cast<nv_bfloat162*>(&sh_b[b_sh_rd]);
           nv_bfloat162 res2 = {};
@@ -140,7 +140,7 @@ __global__ void Code2x8MatVec(
       #pragma unroll
       for (int i = 0; i < 8; i++) {
         if constexpr (use_bfloat16) {
-        #if defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800) || defined(_NVHPC_CUDA))
+        #if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800)
           nv_bfloat162* a0 = reinterpret_cast<nv_bfloat162*>(&sh_code0[8 * enc[2 * i + 0] + lane]);
           nv_bfloat162* a1 = reinterpret_cast<nv_bfloat162*>(&sh_code1[8 * enc[2 * i + 1] + lane]);
           nv_bfloat162*  b = reinterpret_cast<nv_bfloat162*>(&sh_b[b_sh_rd]);
@@ -195,14 +195,12 @@ void  code1x16_matvec_cuda(
   int prob_k,
   bool use_bfloat16
 ) {
-  #if !(defined(__CUDACC__) && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800) || defined(_NVHPC_CUDA)))
+  #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800)
   if (use_bfloat16) {
     throw c10::TypeError(
       {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},
       c10::str(
-        "You're trying to run AQLM with bfloat16 on a GPU with compute capability ",
-        __CUDA_ARCH__,
-        ", and you need at least 8.0 to do that. Use torch.float16 instead."
+        "You're trying to run AQLM with bfloat16 on a GPU with low compute capability. Use torch.float16 instead."
       )
     );
   } 
@@ -250,6 +248,17 @@ void  code2x8_matvec_cuda(
   int prob_k,
   bool use_bfloat16
 ) {
+  #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800)
+  if (use_bfloat16) {
+    throw c10::TypeError(
+      {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},
+      c10::str(
+        "You're trying to run AQLM with bfloat16 on a GPU with low compute capability. Use torch.float16 instead."
+      )
+    );
+  } 
+  #endif
+
   int sms;
   cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);
   int waves = 0;


### PR DESCRIPTION
`bfloat16` is not supported on T4 and GPU with the same or lower Compute Capability, meaning the kernels will throw an error compiling.
This PR isolates the code behind CC check and throws a runtime error if kernel is not available.