### PR TITLE
Typo: check if nsamples is None

### DIFF
--- a/main.py
+++ b/main.py
@@ -806,7 +806,8 @@ if __name__ == "__main__":
     assert all(isinstance(device, torch.device) for device in args.devices)
 
     # validate val size
-    assert args.val_size < args.nsamples, "Number of validation set must be smaller than train + val"
+    if args.nsamples is not None:
+        assert args.val_size < args.nsamples, "Number of validation set must be smaller than train + val"
 
     if args.wandb:
         assert has_wandb, "`wandb` not installed, try pip install `wandb`"


### PR DESCRIPTION
The PR fixes the rare error  that occurs if nsamples is not specified, e.g. when the main.py is ran for the purpose of evaluaiton

![image](https://github.com/Vahe1994/AQLM/assets/3491902/62419d8c-11c7-4a30-ba33-46461a5ed21f)

To reviewer: if you believe that the PR can be merged, please merge this by yourself (i.e. without checking with me).
