### PR TITLE
Option to resume previously interrupted calibration, fix edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,11 @@ python main.py $MODEL_PATH $DATASET_PATH \
  --finetune_batch_size=32 \
  --finetune_max_epochs=10 \
  --finetune_early_stop=3 \
+ --finetune_keep_best \
  --local_batch_size=1 \
  --offload_activations \
  --wandb \
+ --resume \
  --save $SAVE_PATH
 ```
 

--- a/finetune.py
+++ b/finetune.py
@@ -45,6 +45,7 @@ def kl_div(student_hiddens, teacher_hiddens, temp):
 def evaluate(model, lm_head, loader, hiddens, batch_size):
     model.eval()
     loss_numerator, loss_denominator = 0, 0
+    device = next(model.parameters()).device
     # convert tensor to list
     for i in range(0, len(loader), batch_size):
         batch_ids = range(i, i + batch_size)

--- a/finetune.py
+++ b/finetune.py
@@ -42,7 +42,7 @@ def kl_div(student_hiddens, teacher_hiddens, temp):
 
 
 @torch.no_grad()
-def evalulate(model, lm_head, loader, hiddens, batch_size):
+def evaluate(model, lm_head, loader, hiddens, batch_size):
     model.eval()
     loss_numerator, loss_denominator = 0, 0
     # convert tensor to list
@@ -80,7 +80,7 @@ def finetune(model, train_loader, train_hiddens, args, device, val_loader=None, 
     run_validation = val_loader is not None and val_hiddens is not None
     # validate before training
     if run_validation:
-        valid_loss_epoch = evalulate(model, lm_head, val_loader, val_hiddens, args.microbatch_size)
+        valid_loss_epoch = evaluate(model, lm_head, val_loader, val_hiddens, args.microbatch_size)
         print(f"Evaluation before training.")
         print(f"valid loss={valid_loss_epoch:.3e}\t")
         best_loss = valid_loss_epoch
@@ -125,7 +125,7 @@ def finetune(model, train_loader, train_hiddens, args, device, val_loader=None, 
         train_loss_epoch = loss_numerator / loss_denominator
 
         if run_validation:
-            valid_loss_epoch = evalulate(model, lm_head, val_loader, val_hiddens, args.microbatch_size)
+            valid_loss_epoch = evaluate(model, lm_head, val_loader, val_hiddens, args.microbatch_size)
 
         # log losses in the end of the epoch
         print("-" * 10)

--- a/finetune.py
+++ b/finetune.py
@@ -322,7 +322,7 @@ if __name__ == "__main__":
         train_dataloader = dataloader
         val_dataloader = None
     # create original model
-    orig_model = get_model(args.base_model, None, args.dtype, args.model_seqlen, args.device_map)
+    orig_model = get_model(args.base_model, None, args.dtype, args.device_map)
     if not args.device_map:
         orig_model = orig_model.to(device)
     # cache logits
@@ -333,7 +333,7 @@ if __name__ == "__main__":
         orig_val_hiddens = None
     del orig_model
     torch.cuda.empty_cache()
-    quant_model = get_model(args.base_model, args.quant_model, args.dtype, args.model_seqlen, args.device_map)
+    quant_model = get_model(args.base_model, args.quant_model, args.dtype, args.device_map)
     if not args.device_map:
         quant_model = quant_model.to(device)
 
@@ -365,15 +365,13 @@ if __name__ == "__main__":
         shutil.copy(os.path.join(args.quant_model, "args.pt"), os.path.join(args.save, "args.pt"))
 
     print("\n============ Evaluating perplexity... ============")
-    if args.eval_model_seqlen:
-        quant_model.seqlen = args.eval_model_seqlen
     torch.cuda.reset_peak_memory_stats()
     for dataset in args.eval_datasets:
         testloader = get_loaders(
             dataset,
             seed=args.seed,
             model_path=args.base_model,
-            seqlen=quant_model.seqlen,
+            seqlen=args.eval_model_seqlen or args.model_seqlen,
             eval_mode=True,
         )
         args.dataset_name = dataset

--- a/lmeval.py
+++ b/lmeval.py
@@ -116,7 +116,6 @@ def main():
     if args.load:
         print("Loading quantized model ...")
         lm.model = load_dequantized_model(lm.model, args.load)
-        lm.model.seqlen = args.model_seqlen
 
     results = evaluator.simple_evaluate(
         model=lm,

--- a/main.py
+++ b/main.py
@@ -79,7 +79,7 @@ def get_inps(
             for i in range(0, data.numel() // model_seqlen)
         ]
     else:
-        assert max(sequence.shape[1] for sequence in data) <= model_seqlen
+        assert all(sequence.shape[1] == model_seqlen for sequence in data)
 
     emb = model.get_input_embeddings()
     emb_device = emb.weight.device

--- a/main.py
+++ b/main.py
@@ -78,8 +78,8 @@ def get_inps(
         data = [data[:, i * model_seqlen: (i + 1) * model_seqlen].to(device) for i in range(num_sequences)]
         print(f"Got {len(data)} sequences of {model_seqlen} tokens, dropped last {num_tokens_dropped} tokens")
         del num_sequences, num_tokens_dropped
-    else:
-        assert all(sequence.shape[1] == model_seqlen for sequence in data)
+
+    assert all(sequence.shape[1] == model_seqlen for sequence in data)
 
     emb = model.get_input_embeddings()
     emb_device = emb.weight.device
@@ -139,7 +139,6 @@ def get_inps(
         except CatcherExit:
             pass  # exit after catcher finished without running the rest of the model layers
 
-    assert cache["i"] == sum(map(len, inps)), (cache["i"], list(map(len, inps)))
     torch.set_num_threads(saved_num_threads)
     layers[0] = layers[0].module
 

--- a/main.py
+++ b/main.py
@@ -403,7 +403,7 @@ def perplexity_eval(model: PreTrainedModel, testenc: torch.LongTensor, args: Nam
         loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
         neg_log_likelihood = loss.float() * args.model_seqlen
         nlls.append(neg_log_likelihood)
-    ppl = torch.exp(torch.stack(nlls).sum().item() / (nsamples * args.model_seqlen))
+    ppl = float(torch.exp(torch.stack(nlls).sum().item()) / (nsamples * args.model_seqlen))
     print(f"\n{args.dataset_name} perplexity = {ppl:.4f}\n")
 
     get_model_head(model).to(torch.device("cpu"))

--- a/main.py
+++ b/main.py
@@ -313,17 +313,17 @@ def quantize_aq(model: PreTrainedModel, data: Sequence, val_data: Optional[Seque
             if args.on_save:
                 exec(args.on_save)  # a callback e.g. to save progress in slurm or similar distributed infrastructure
 
+        should_compute_mse = not (args.skip_out_loss or loaded_layer)
         if len(args.devices) == 1:
             assert len(inps) == len(outs) == 1
-            out_losses = update_outs(layer, inps[0], outs[0], compute_mse=not args.skip_out_loss, **forward_args)
+            out_losses = update_outs(layer, inps[0], outs[0], compute_mse=should_compute_mse, **forward_args)
         else:
             out_losses = update_outs_parallel(
-                args.devices, layer, inps, outs, compute_mse=not args.skip_out_loss, **forward_args
+                args.devices, layer, inps, outs, compute_mse=should_compute_mse, **forward_args
             )
         stats_payload["out_loss"] = torch.mean(torch.Tensor(out_losses)).item()
 
         if run_validation:
-            should_compute_mse = not (args.skip_out_loss or loaded_layer)
             if len(args.devices) == 1:
                 assert len(val_inps) == len(val_outs) == 1
                 out_val_losses = update_outs(

--- a/main.py
+++ b/main.py
@@ -402,7 +402,7 @@ def perplexity_eval(model: PreTrainedModel, testenc: torch.LongTensor, args: Nam
         loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
         neg_log_likelihood = loss.float() * args.model_seqlen
         nlls.append(neg_log_likelihood)
-    ppl = float(torch.exp(torch.stack(nlls).sum().item()) / (nsamples * args.model_seqlen))
+    ppl = torch.exp(torch.stack(nlls).sum()).item() / (nsamples * args.model_seqlen)
     print(f"\n{args.dataset_name} perplexity = {ppl:.4f}\n")
 
     get_model_head(model).to(torch.device("cpu"))

--- a/main.py
+++ b/main.py
@@ -403,13 +403,13 @@ def perplexity_eval(model: PreTrainedModel, testenc: torch.LongTensor, args: Nam
         loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
         neg_log_likelihood = loss.float() * args.model_seqlen
         nlls.append(neg_log_likelihood)
-    ppl = torch.exp(torch.stack(nlls).sum() / (nsamples * args.model_seqlen))
-    print(f"\n{args.dataset_name} perplexity = {ppl.item():.4f}\n")
+    ppl = torch.exp(torch.stack(nlls).sum().item() / (nsamples * args.model_seqlen))
+    print(f"\n{args.dataset_name} perplexity = {ppl:.4f}\n")
 
     get_model_head(model).to(torch.device("cpu"))
 
     if args.wandb:
-        wandb.log({args.dataset_name: ppl.item()})
+        wandb.log({args.dataset_name: ppl})
 
     model.config.use_cache = use_cache
     return ppl

--- a/main.py
+++ b/main.py
@@ -306,6 +306,8 @@ def quantize_aq(
             layer_save_path = os.path.join(args.save, f"{layer_index}.pth")
             print(f"Saving layer {layer_index}... to {layer_save_path}")
             torch.save(layer, layer_save_path)
+            if args.on_save:
+                exec(args.on_save)  # a callback e.g. to save progress in slurm or similar distributed infrastructure
 
         if len(args.devices) == 1:
             assert len(inps) == len(outs) == 1

--- a/main.py
+++ b/main.py
@@ -404,6 +404,7 @@ def perplexity_eval(model: PreTrainedModel, testenc: torch.LongTensor, args: Nam
         loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
         neg_log_likelihood = loss.float() * args.model_seqlen
         nlls.append(neg_log_likelihood)
+        print('nll ith =', neg_log_likelihood)
     ppl = torch.exp(torch.stack(nlls).sum()).item() / (nsamples * args.model_seqlen)
     print(f"\n{args.dataset_name} perplexity = {ppl:.4f}\n")
 

--- a/main.py
+++ b/main.py
@@ -76,8 +76,9 @@ def get_inps(
         assert data.ndim == 2, "data must be either a single tensor with a long sequence or a list of pre-cut sequences"
         data = [
             data[:, i * model_seqlen: (i + 1) * model_seqlen].to(device)
-            for i in range(0, data.numel() // model_seqlen)
+            for i in range(data.numel() // model_seqlen)
         ]
+        print(f"Got {len(data)} sequences of {model_seqlen} tokens, dropped last {data.numel() % model_seqlen} tokens")
     else:
         assert all(sequence.shape[1] == model_seqlen for sequence in data)
 

--- a/main.py
+++ b/main.py
@@ -320,14 +320,15 @@ def quantize_aq(
         stats_payload["out_loss"] = torch.mean(torch.Tensor(out_losses)).item()
 
         if run_validation:
+            should_compute_mse = not (args.skip_out_loss or loaded_layer)
             if len(args.devices) == 1:
                 assert len(val_inps) == len(val_outs) == 1
                 out_val_losses = update_outs(
-                    layer, val_inps[0], val_outs[0], compute_mse=not (args.skip_out_loss or loaded_layer), **forward_args
+                    layer, val_inps[0], val_outs[0], compute_mse=should_compute_mse, **forward_args
                 )
             else:
                 out_val_losses = update_outs_parallel(
-                    args.devices, layer, val_inps, val_outs, compute_mse=not (args.skip_out_loss or loaded_layer), **forward_args
+                    args.devices, layer, val_inps, val_outs, compute_mse=should_compute_mse, **forward_args
                 )
             stats_payload["out_val_loss"] = torch.mean(torch.Tensor(out_val_losses)).item()
 

--- a/main.py
+++ b/main.py
@@ -405,7 +405,7 @@ def perplexity_eval(model: PreTrainedModel, testenc: torch.LongTensor, args: Nam
         loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
         neg_log_likelihood = loss.float() * args.model_seqlen
         nlls.append(neg_log_likelihood)
-    ppl = torch.exp(torch.stack(nlls).sum()).item() / (nsamples * args.model_seqlen)
+    ppl = torch.exp(torch.stack(nlls).sum() / (nsamples * args.model_seqlen)).item()
     print(f"\n{args.dataset_name} perplexity = {ppl:.4f}\n")
 
     get_model_head(model).to(torch.device("cpu"))

--- a/main.py
+++ b/main.py
@@ -138,6 +138,8 @@ def get_inps(
             model(batch_inps, attention_mask=torch.ones_like(batch_inps))
         except CatcherExit:
             pass  # exit after catcher finished without running the rest of the model layers
+
+    assert cache["i"] == len(inps), (cache["i"], len(inps))
     torch.set_num_threads(saved_num_threads)
     layers[0] = layers[0].module
 
@@ -404,7 +406,6 @@ def perplexity_eval(model: PreTrainedModel, testenc: torch.LongTensor, args: Nam
         loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
         neg_log_likelihood = loss.float() * args.model_seqlen
         nlls.append(neg_log_likelihood)
-        print('nll ith =', neg_log_likelihood)
     ppl = torch.exp(torch.stack(nlls).sum()).item() / (nsamples * args.model_seqlen)
     print(f"\n{args.dataset_name} perplexity = {ppl:.4f}\n")
 

--- a/main.py
+++ b/main.py
@@ -139,7 +139,7 @@ def get_inps(
         except CatcherExit:
             pass  # exit after catcher finished without running the rest of the model layers
 
-    assert cache["i"] == len(inps), (cache["i"], len(inps))
+    assert cache["i"] == sum(map(len, inps)), (cache["i"], list(map(len, inps)))
     torch.set_num_threads(saved_num_threads)
     layers[0] = layers[0].module
 

--- a/main.py
+++ b/main.py
@@ -74,11 +74,10 @@ def get_inps(
 
     if isinstance(data, torch.Tensor) and data.shape[0] == 1:  # given a single long tensor, split it into sequences
         assert data.ndim == 2, "data must be either a single tensor with a long sequence or a list of pre-cut sequences"
-        data = [
-            data[:, i * model_seqlen: (i + 1) * model_seqlen].to(device)
-            for i in range(data.numel() // model_seqlen)
-        ]
-        print(f"Got {len(data)} sequences of {model_seqlen} tokens, dropped last {data.numel() % model_seqlen} tokens")
+        num_sequences, num_tokens_dropped = data.numel() // model_seqlen, data.numel() % model_seqlen
+        data = [data[:, i * model_seqlen: (i + 1) * model_seqlen].to(device) for i in range(num_sequences)]
+        print(f"Got {len(data)} sequences of {model_seqlen} tokens, dropped last {num_tokens_dropped} tokens")
+        del num_sequences, num_tokens_dropped
     else:
         assert all(sequence.shape[1] == model_seqlen for sequence in data)
 

--- a/main.py
+++ b/main.py
@@ -348,7 +348,8 @@ def quantize_aq(model: PreTrainedModel, data: Sequence, val_data: Optional[Seque
         stats_payload["Step"] = layer_index
         if args.wandb:
             wandb.log(stats_payload, step=layer_index)
-        print(stats_payload)
+        if not loaded_layer:
+            print(stats_payload)
 
     print("=====================\nFinal stats:")
     if args.save:

--- a/main.py
+++ b/main.py
@@ -155,6 +155,7 @@ def get_inps(
     torch.cuda.empty_cache()
 
     forward_args = {k: cache[k] for k in forward_arg_names}
+    assert cache["i"] == sum(len(inp_tensor) for inp_tensor in inps), "internal error: found empty rows in inps"
     return inps, forward_args
 
 
@@ -512,7 +513,7 @@ def init_aq_engines_parallel(
         total_nsamples = sum(replica_nsamples)
         aq_handler.XTX = sum(
             (replica_handlers[i].XTX * (replica_nsamples[i] / total_nsamples)).to(devices[0], non_blocking=True)
-            for i in range(len(devices))
+            for i in range(len(devices) )
         )
         aq_handler.nsamples = total_nsamples
     return aq_handlers

--- a/main.py
+++ b/main.py
@@ -514,7 +514,7 @@ def init_aq_engines_parallel(
         total_nsamples = sum(replica_nsamples)
         aq_handler.XTX = sum(
             (replica_handlers[i].XTX * (replica_nsamples[i] / total_nsamples)).to(devices[0], non_blocking=True)
-            for i in range(len(devices) )
+            for i in range(len(devices))
         )
         aq_handler.nsamples = total_nsamples
     return aq_handlers

--- a/src/modelutils.py
+++ b/src/modelutils.py
@@ -39,7 +39,7 @@ def dispatch_quantized_model(model):
 
 
 def get_model(
-    model_path, load_quantized=None, dtype="auto", model_seqlen=2048, device_map=None, attn_implementation=None
+    model_path, load_quantized=None, dtype="auto", device_map=None, attn_implementation=None
 ):
     if dtype == "auto":
         dtype = (
@@ -74,7 +74,6 @@ def get_model(
         else:
             print("Loading pretrained model ...")
 
-    model.seqlen = model_seqlen
     print("Model loaded sucсessfully ...")
 
     return model

--- a/src/modelutils.py
+++ b/src/modelutils.py
@@ -38,9 +38,7 @@ def dispatch_quantized_model(model):
     return model
 
 
-def get_model(
-    model_path, load_quantized=None, dtype="auto", device_map=None, attn_implementation=None
-):
+def get_model(model_path, load_quantized=None, dtype="auto", device_map=None, attn_implementation=None):
     if dtype == "auto":
         dtype = (
             AutoConfig.from_pretrained(model_path, trust_remote_code=True).torch_dtype or "auto"


### PR DESCRIPTION
This PR introduces an option to resume calibration from partially quantized model, with the following use cases
- when quantizing a particularly large model (looking at you, grok!), you may run the job every night and stop it during daytime to free GPUs for other tasks
- if the original run crashed due to OOM or other means, one can resume without losing (almost) any progress
- when calibrating on preemptible hardware (e.g. spot instances), one can begin training on one server, then switch to another server when the first one is preempted.
- when calibration went well for most layers, but then loss exploded at *some* layer close to the end (e.g. due to too large an LR), one can change parameters and re-train from that layer on

To this end, the PR introduces two new options to `main.py`:
- `--resume` - if enabled, the calibration code will check if `--save` path already contains previously quantized blocks
   - if a pre-quantized block exists, the code will load it instead of 1) calibrating individual linear layers within that block and 2) fine-tuning the block itself to optimize MSE
  - this option **requires** `--save` to be enabled
- `--on_save="import my_cloud_saver as s; s.save_to_cloud()"` - users may specify the code to run after each block
  - the most obvious use case is when running on preemptible VMs; use this option to upload the quantized blocks to persistent storage (e.g. S3 for AWS spot VMs)
  - another less obvious use case is to upload the model to HF hub as it is quantized
  - since you can write python code here, you can also make it send you notifications or do some other bizarre things


Note that recovering from partial quantization is not instantaneous: the model still needs to compute input activations  by running forward pass on any previously quantized blocks. This takes some time, but is typically 1 or 2 orders of magnitude faster than quantizing them from scratch, depending on the number of training data points. The reason we re-run forward pass and not save these activations is that they are typically huge, much larger than the entire model.