### PR TITLE
Make old *training* datasets compatible again

### DIFF
--- a/src/datautils.py
+++ b/src/datautils.py
@@ -47,9 +47,7 @@ def get_wikitext2(nsamples, seqlen, tokenizer, eval_mode=False):
             i = random.randint(0, trainenc.input_ids.shape[1] - seqlen - 1)
             j = i + seqlen
             inp = trainenc.input_ids[:, i:j]
-            tar = inp.clone()
-            tar[:, :-1] = -100
-            trainloader.append((inp, tar))
+            trainloader.append(inp)
         return trainloader
     else:
         testdata = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
@@ -66,9 +64,7 @@ def get_ptb(nsamples, seqlen, tokenizer, eval_mode=False):
             i = random.randint(0, trainenc.input_ids.shape[1] - seqlen - 1)
             j = i + seqlen
             inp = trainenc.input_ids[:, i:j]
-            tar = inp.clone()
-            tar[:, :-1] = -100
-            trainloader.append((inp, tar))
+            trainloader.append(inp)
         return trainloader
     else:
         valdata = load_dataset("ptb_text_only", "penn_treebank", split="validation")
@@ -95,9 +91,7 @@ def get_c4(nsamples, seqlen, tokenizer, eval_mode=False):
             i = random.randint(0, trainenc.input_ids.shape[1] - seqlen - 1)
             j = i + seqlen
             inp = trainenc.input_ids[:, i:j]
-            tar = inp.clone()
-            tar[:, :-1] = -100
-            trainloader.append((inp, tar))
+            trainloader.append(inp)
         return trainloader
 
     else:


### PR DESCRIPTION
Noticed by @BlackSamorez 


If we use wikitext as *training* data, the code would previously fail, because it uses an old (incompatible) dataset format:
```
(base) jheuristic@ultramar:/home/jheuristic/AQLM$ git pull && TRANSFORMERS_CACHE="/mnt/LLM/hub" OMP_NUM_THREADS=16 MKL_NUM_THREADS=16 CUDA_VISIBLE_DEVICES=5 python main.py "TinyLlama/TinyLlama-1.1B-interm
ediate-step-1431k-3T" "wikitext2" --dtype float16 --relative_mse_tolerance=0.01 --nsamples=2048 --val_size=256 --model_seqlen=2048 --num_codebooks=2 --nbits_per_codebook=8 --beam_size=8 --in_group_size=8
--wandb --finetune_keep_best --finetune_batch_size=64 --local_batch_size=4 --finetune_early_stop=3 --finetune_max_epochs=50
wandb: Currently logged in as: justheuristic (hivemind_cv). Use `wandb login --relogin` to force relogin
wandb: wandb version 0.16.6 is available!  To upgrade, please run:           
wandb:  $ pip install wandb --upgrade
wandb: Tracking run with wandb version 0.16.0                                                                                                                                                               wandb: Run data is saved locally in /home/jheuristic/AQLM/wandb/run-20240411_132852-c5eefh3n                                                                                                               
wandb: Run `wandb offline` to turn off syncing.                                                                            
wandb: Syncing run super-morning-59                                                                           
wandb: ⭐️ View project at https://wandb.ai/hivemind_cv/AQLM
wandb: 🚀 View run at https://wandb.ai/hivemind_cv/AQLM/runs/c5eefh3n
                                                                                                                                                                                                            ============ Load model... ============
Loading pretrained model ...
Model loaded sucсessfully ...                                                                           
                                                                  
============ Quantizing model... ============
Loading data ...                             
/home/jheuristic/anaconda3/lib/python3.9/site-packages/scipy/__init__.py:146: UserWarning: A NumPy version >=1.16.5 and <1.23.0 is required for this version of SciPy (detected version 1.25.0
  warnings.warn(f"A NumPy version >={np_minversion} and <{np_maxversion}"
Loaded data from wikitext2; len(data)=2048 sequences
                                                           
Starting AQ quantization ...                                         
catching layer inputs from data
Traceback (most recent call last):     
  File "/home/jheuristic/AQLM/main.py", line 871, in <module>
    quantize_model(model, args)
  File "/home/jheuristic/AQLM/main.py", line 57, in quantize_model
    results = quantize_aq(model, train_data, val_data, args)
  File "/home/jheuristic/anaconda3/lib/python3.9/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)                                                                                                                                                              
  File "/home/jheuristic/AQLM/main.py", line 166, in quantize_aq         
    inps, forward_args = get_inps(model, data, args.model_seqlen, args.devices, args.offload_activations)
  File "/home/jheuristic/anaconda3/lib/python3.9/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/jheuristic/AQLM/main.py", line 86, in get_inps
    assert all(sequence.shape[1] == model_seqlen for sequence in data)
  File "/home/jheuristic/AQLM/main.py", line 86, in <genexpr>
    assert all(sequence.shape[1] == model_seqlen for sequence in data)
AttributeError: 'tuple' object has no attribute 'shape'

```


In the new version, the same script produces
![image](https://github.com/Vahe1994/AQLM/assets/3491902/71b0d0c5-f7c7-4808-aa62-2167368c0580)
