### PR TITLE
Fixed device placement for Llama-2 and added tuning in bfloat16

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ python finetune.py \
   --early_stop=3 \
   --batch_size=8 \
   --microbatch_size=4 \
-  --temperature=1.0 \
   --save $DATA_PATH \
   --gradient_checkpointing
 ```
@@ -226,6 +225,8 @@ Main CLI arguments:
 - `--nsamples` - the number of calibration data _sequences_ (train + validation). If this parameter is not set, take all calibration data avaialble.
 - `--val_size` - the number of validation sequences for early stopping on end-to-end finetuning. By default equal to 0. Must be smaller than `--nsamples`.
 - `--gradient_checkpointing` - whether to use gradient checkpointing. Reduces peak memory usage at the cost of longer runtime.
+- `--finetune_dtype` - which dtype should be used on finetuning. By default `float32`. 
+- `--amp` - whether to use amp on finetuning. Requires `--finetune_dtype=float32`.
 
 **Note** for larger models one would need multi-GPU training. At the moment, FSDP training is not implemented and the model is finetuned on a single process with parameters sharded across available devices.
 

--- a/finetune.py
+++ b/finetune.py
@@ -32,7 +32,7 @@ def cache_hiddens(model, dataloader):
     return cached_hiddens
 
 
-def kl_div(student_hiddens, teacher_hiddens, temp):
+def kl_div(student_hiddens, teacher_hiddens, temp=1.0):
     C = student_hiddens.shape[-1]  # num classes
     return temp**2 * F.kl_div(
         input=F.log_softmax(student_hiddens.view(-1, C) / temp, dim=-1),
@@ -43,7 +43,7 @@ def kl_div(student_hiddens, teacher_hiddens, temp):
 
 
 @torch.no_grad()
-def evaluate(model, lm_head, loader, hiddens, batch_size):
+def evaluate(model, lm_head, loader, hiddens, batch_size, dtype):
     model.eval()
     loss_numerator, loss_denominator = 0, 0
     device = next(model.parameters()).device
@@ -51,17 +51,17 @@ def evaluate(model, lm_head, loader, hiddens, batch_size):
     for i in range(0, len(loader), batch_size):
         batch_ids = range(i, i + batch_size)
         inputs = _extract_into_tensor(loader, batch_ids, device=device)
-        targets = lm_head(_extract_into_tensor(hiddens, batch_ids, device=device).float())
+        targets = lm_head(_extract_into_tensor(hiddens, batch_ids, device=device, dtype=dtype))
         outputs = model(inputs).logits
-        loss = kl_div(outputs, targets.to(outputs.device), args.temperature)
+        loss = kl_div(outputs, targets.to(outputs.device))
         loss_numerator += loss.item()
         loss_denominator += 1
     return loss_numerator / loss_denominator
 
 
 def finetune(model, train_loader, train_hiddens, args, device, val_loader=None, val_hiddens=None):
-    # cast model to float
-    model.float()
+    # cast model to finetune dtype
+    model.to(args.finetune_dtype)
     lm_head = deepcopy(model.lm_head)
     for param in lm_head.parameters():
         param.requires_grad = False
@@ -82,7 +82,7 @@ def finetune(model, train_loader, train_hiddens, args, device, val_loader=None, 
     run_validation = val_loader is not None and val_hiddens is not None
     # validate before training
     if run_validation:
-        valid_loss_epoch = evaluate(model, lm_head, val_loader, val_hiddens, args.microbatch_size)
+        valid_loss_epoch = evaluate(model, lm_head, val_loader, val_hiddens, args.microbatch_size, args.finetune_dtype)
         print(f"Evaluation before training.")
         print(f"valid loss={valid_loss_epoch:.3e}\t")
         best_loss = valid_loss_epoch
@@ -102,11 +102,13 @@ def finetune(model, train_loader, train_hiddens, args, device, val_loader=None, 
             batch_indices = batch_indices.tolist()
             inputs = _extract_into_tensor(train_loader, batch_indices, device=device)
             with torch.no_grad():
-                targets = lm_head(_extract_into_tensor(train_hiddens, batch_indices, device=device).float())
+                targets = lm_head(
+                    _extract_into_tensor(train_hiddens, batch_indices, device=device, dtype=args.finetune_dtype)
+                )
 
             with torch.autocast(device_type="cuda", enabled=args.amp):
                 outputs = model(inputs).logits
-                loss = kl_div(outputs, targets.to(outputs.device), args.temperature)
+            loss = kl_div(outputs, targets.to(device=outputs.device, dtype=args.finetune_dtype))
 
             if not torch.isfinite(loss).item():
                 raise ValueError(f"Fine-tuning loss is {loss}")
@@ -127,7 +129,9 @@ def finetune(model, train_loader, train_hiddens, args, device, val_loader=None, 
         train_loss_epoch = loss_numerator / loss_denominator
 
         if run_validation:
-            valid_loss_epoch = evaluate(model, lm_head, val_loader, val_hiddens, args.microbatch_size)
+            valid_loss_epoch = evaluate(
+                model, lm_head, val_loader, val_hiddens, args.microbatch_size, args.finetune_dtype
+            )
 
         # log losses in the end of the epoch
         print("-" * 10)
@@ -154,6 +158,11 @@ def finetune(model, train_loader, train_hiddens, args, device, val_loader=None, 
 
     if run_validation:
         model.load_state_dict(best_params, strict=False)
+
+
+def print_memory_stats():
+    print(f"GPU max memory allocated: {torch.cuda.max_memory_allocated() / 2 ** 30:.2f} GB.")
+    print(f"GPU max memory reserved: {torch.cuda.max_memory_reserved() / 2 ** 30:.2f} GB.")
 
 
 if __name__ == "__main__":
@@ -246,12 +255,6 @@ if __name__ == "__main__":
         help="training microbatch size",
     )
     parser.add_argument(
-        "--temperature",
-        type=float,
-        default=1.0,
-        help="Distillation temperature",
-    )
-    parser.add_argument(
         "--gradient_checkpointing",
         action="store_true",
         help="Whether to apply gradient checkpointing",
@@ -266,6 +269,13 @@ if __name__ == "__main__":
         type=int,
         default=3,
         help="Terminate finetuning if loss doesn't improve after this number of epochs.",
+    )
+    parser.add_argument(
+        "--finetune_dtype",
+        type=str,
+        default="float32",
+        choices=["float16", "float32", "bfloat16"],
+        help="dtype to finetune the model",
     )
     # Logging params
     parser.add_argument("--wandb", action="store_true", help="Whether to use wandb or store locally.")
@@ -310,6 +320,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     args.microbatch_size = args.microbatch_size or args.batch_size
+    args.finetune_dtype = getattr(torch, args.finetune_dtype)
+    if args.amp:
+        assert args.finetune_dtype == torch.float32, "AMP works only with original model in fp32."
     # get device
     assert torch.cuda.is_available()
     device = "cuda"
@@ -363,6 +376,8 @@ if __name__ == "__main__":
         val_loader=val_dataloader,
         val_hiddens=orig_val_hiddens,
     )
+
+    print_memory_stats()
 
     # offload model to cpu
     quant_model = quant_model.cpu()

--- a/finetune.py
+++ b/finetune.py
@@ -32,11 +32,11 @@ def cache_hiddens(model, dataloader):
     return cached_hiddens
 
 
-def kl_div(student_hiddens, teacher_hiddens, temp=1.0):
+def kl_div(student_hiddens, teacher_hiddens):
     C = student_hiddens.shape[-1]  # num classes
-    return temp**2 * F.kl_div(
-        input=F.log_softmax(student_hiddens.view(-1, C) / temp, dim=-1),
-        target=F.log_softmax(teacher_hiddens.view(-1, C) / temp, dim=-1),
+    return F.kl_div(
+        input=F.log_softmax(student_hiddens.view(-1, C), dim=-1),
+        target=F.log_softmax(teacher_hiddens.view(-1, C), dim=-1),
         log_target=True,
         reduction="batchmean",
     )

--- a/src/modelutils.py
+++ b/src/modelutils.py
@@ -28,11 +28,7 @@ def suspend_nn_inits():
 
 def dispatch_quantized_model(model):
     num_devices = torch.cuda.device_count()
-    device_map = {
-        "model.embed_tokens": 0,
-        "model.norm": num_devices - 1,
-        "lm_head": 0 if model.config.model_type == "cohere" else num_devices - 1,
-    }
+    device_map = {"model.embed_tokens": 0, "model.norm": num_devices - 1, "lm_head": 0}
     num_layers = len(get_layers(model))
     layers_per_device = math.ceil(num_layers / num_devices)
     for layer_id in range(num_layers):

--- a/src/utils.py
+++ b/src/utils.py
@@ -114,6 +114,6 @@ def maybe_get_0th_element(x: Union[Any, Sequence[Any]]) -> Any:
     return x
 
 
-def _extract_into_tensor(tensor_list: List[torch.Tensor], indices: Iterable[int], device=None):
+def _extract_into_tensor(tensor_list: List[torch.Tensor], indices: Iterable[int], device=None, dtype=None):
     extracted_items = [maybe_get_0th_element(tensor_list[i]) for i in indices]
-    return torch.cat(extracted_items, dim=0).to(device)
+    return torch.cat(extracted_items, dim=0).to(device=device, dtype=dtype)


### PR DESCRIPTION
Summary of changes:

1) Fixed bug that leads to device mistmatch in `finetune.py`
2) Added tuning in bfloat16 that may reduce memory usage. 
3) Removed `--temperature` argument.

Below mem usage for several options is shown.
<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
dtype | amp | checkpoint | Max Mem Alloc (GB) | Max Mem Res (GB)
-- | -- | -- | -- | --
float32 | N | Y | 51.61 | 57.91
float32 | Y | Y | 51.26 | 57.91
bfloat16 | N | Y | 44.66 | 62.41





