### PR TITLE
Bug fix for CPU quantization

### DIFF
--- a/main.py
+++ b/main.py
@@ -107,7 +107,7 @@ def get_inps(
             (min(nsamples_per_device, len(data) - i * nsamples_per_device), model_seqlen, model.config.hidden_size),
             dtype=dtype,
             device=devices[i] if not offload_activations else "cpu",
-            pin_memory=offload_activations and devices != [torch.device('cpu')],
+            pin_memory=offload_activations and devices != [torch.device("cpu")],
         )
         for i in range(len(devices))
     ]

--- a/main.py
+++ b/main.py
@@ -184,6 +184,7 @@ def quantize_aq(model: PreTrainedModel, data: Sequence, val_data: Optional[Seque
     overall_bits = 0
     number_of_quantized_params = 0
     layers = get_layers(model)
+
     for layer_index in range(len(layers)):
         print(f"\n---------------- Layer {layer_index} of {len(layers)} ----------------")
         stats_payload = {}

--- a/main.py
+++ b/main.py
@@ -107,7 +107,7 @@ def get_inps(
             (min(nsamples_per_device, len(data) - i * nsamples_per_device), model_seqlen, model.config.hidden_size),
             dtype=dtype,
             device=devices[i] if not offload_activations else "cpu",
-            pin_memory=offload_activations and devices != [torch.device("cpu")],
+            pin_memory=offload_activations,
         )
         for i in range(len(devices))
     ]

--- a/src/finetune.py
+++ b/src/finetune.py
@@ -49,6 +49,7 @@ def finetune_groupwise(
             )
         else:
             assert train_inps[i].device == train_outs[i].device == torch.device("cpu")
+            assert train_inps[i].is_pinned() and train_outs[i].is_pinned()
 
     # replicate non-trainable parameters to each GPU
     replicas = kwargs_by_device = None

--- a/src/finetune.py
+++ b/src/finetune.py
@@ -49,7 +49,6 @@ def finetune_groupwise(
             )
         else:
             assert train_inps[i].device == train_outs[i].device == torch.device("cpu")
-            assert train_inps[i].is_pinned() and train_outs[i].is_pinned()
 
     # replicate non-trainable parameters to each GPU
     replicas = kwargs_by_device = None


### PR DESCRIPTION
**🔥Quantization on CPU**
I was able to run the quantization on CPU with tiny LLama and red_pajama dataset.
Here are some small remark I made to fix some bugs including:

* When we dont have GPU devices we should add only one device: cpu in the array of devices
* We should use pin_memory only when GPU is available
* We should delete the following assert:

```
assert train_inps[i].is_pinned() and train_outs[i].is_pinned()
```

because it does not make sense since we do not use pinned memory without GPU.