### PR TITLE
Reduced memory footprint by storing codes in torch.int32

### DIFF
--- a/src/aq.py
+++ b/src/aq.py
@@ -105,7 +105,7 @@ class QuantizedWeight(nn.Module):
         self.codebooks = nn.Parameter(
             codebooks, requires_grad=True
         )  # [num_codebooks, codebook_size, out_group_size, in_group_size]
-        self.codes = nn.Parameter(codes, requires_grad=False)  #  [num_out_groups, num_in_groups, num_codebooks]
+        self.codes = nn.Parameter(codes.to(torch.int32), requires_grad=False)  #  [num_out_groups, num_in_groups, num_codebooks]
 
     def get_codebooks(self) -> torch.Tensor:
         """Get quantization codebooks or reconstruct them from second level quantization (see codebook_values_nbits)"""

--- a/src/aq.py
+++ b/src/aq.py
@@ -105,7 +105,10 @@ class QuantizedWeight(nn.Module):
         self.codebooks = nn.Parameter(
             codebooks, requires_grad=True
         )  # [num_codebooks, codebook_size, out_group_size, in_group_size]
-        self.codes = nn.Parameter(codes.to(torch.int32), requires_grad=False)  #  [num_out_groups, num_in_groups, num_codebooks]
+        self.codes = nn.Parameter(
+            codes.to(torch.int32),
+            requires_grad=False,
+        )  #  [num_out_groups, num_in_groups, num_codebooks]
 
     def get_codebooks(self) -> torch.Tensor:
         """Get quantization codebooks or reconstruct them from second level quantization (see codebook_values_nbits)"""


### PR DESCRIPTION
I've checked, and it works with Llama2-7b model