### PR TITLE
moved code from if __name__ == "__main__" to main function.

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -165,7 +165,7 @@ def print_memory_stats():
     print(f"GPU max memory reserved: {torch.cuda.max_memory_reserved() / 2 ** 30:.2f} GB.")
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(add_help=True)
     # Model params
     parser.add_argument(
@@ -415,3 +415,7 @@ if __name__ == "__main__":
     print(f"eval: {torch.cuda.max_memory_allocated()=:,}")
     if args.wandb:
         wandb.log({"max_cuda_mem_eval": round(torch.cuda.max_memory_allocated() / 1e9, 2)})
+
+
+if __name__ == "__main__":
+    main()

--- a/finetune.py
+++ b/finetune.py
@@ -22,7 +22,7 @@ from src.utils import _extract_into_tensor, maybe_get_0th_element
 
 
 @torch.inference_mode()
-def cache_hiddens(model, dataloader):
+def cache_hiddens(model, dataloader, args):
     device = next(model.parameters()).device
     cached_hiddens = []
     for i in trange(len(dataloader), total=len(dataloader), desc="Caching hiddens", leave=False):
@@ -353,9 +353,9 @@ def main():
     if not args.device_map:
         orig_model = orig_model.to(device)
     # cache logits
-    orig_train_hiddens = cache_hiddens(orig_model, train_dataloader)
+    orig_train_hiddens = cache_hiddens(orig_model, train_dataloader, args)
     if val_dataloader:
-        orig_val_hiddens = cache_hiddens(orig_model, val_dataloader)
+        orig_val_hiddens = cache_hiddens(orig_model, val_dataloader, args)
     else:
         orig_val_hiddens = None
     del orig_model

--- a/main.py
+++ b/main.py
@@ -580,7 +580,7 @@ def update_outs_parallel(
     return list(chain(*out_losses_by_device))
 
 
-if __name__ == "__main__":
+def main():
     import argparse
 
     parser = argparse.ArgumentParser(add_help=True)
@@ -912,3 +912,7 @@ if __name__ == "__main__":
     print(f"eval: {torch.cuda.max_memory_allocated()=:,}")
     if args.wandb:
         wandb.log({"max_cuda_mem_eval": round(torch.cuda.max_memory_allocated() / 1e9, 2)})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This way variables won't leak into scopes of other functions.

We've already [encountered](https://github.com/Vahe1994/AQLM/pull/69/files#diff-a5ff12394959301eb25d323d44fc987a79336e66a44eb3e4def7ae3515f35430R48) a bug because of this.

Official python documentation [advices](https://docs.python.org/3/library/__main__.html#idiomatic-usage) to write code this way just for that reason
> This is error-prone as other functions within the module could be unintentionally using the global variable instead of a local name. A main function solves this problem.