### PR TITLE
Fix formatting and better explain model conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ To convert a model into a _Hugging Face_ compatible format, use `convert_to_hf.p
 
 You may also specify flags such as `--save_safetensors` to control the saved model format (see `--help` for details).
 
-Example command: `python convert_to_hf.py meta-llama/Llama-2-7b-hf ./path/to/saved/quantization ./converted-llama2-7b-hf  --save_safetensors
+Example command: `python convert_to_hf.py meta-llama/Llama-2-7b-hf ./path/to/saved/quantization ./converted-llama2-7b-hf  --save_safetensors`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -269,12 +269,14 @@ python lmeval.py \
 
 ### Preparing models for inference
 
-To convert a model into a _Hugging Face_ compatible format, use `convert_to_hf.py` with corresponding arguments:
- - `--model` - the original pretrained model (corresponds to `MODEL_PATH` of `main.py`, e.g. `meta-llama/Llama-2-7b-hf`).
- - `--in_path` - the folder containing an initially quantized model (corresponds to `--save` of `main.py`).
- - `--out_path` - the folder to save `transformers` model to.
+To convert a model into a _Hugging Face_ compatible format, use `convert_to_hf.py model in_path out_path` with corresponding arguments:
+ - `model` - the original pretrained model (corresponds to `MODEL_PATH` of `main.py`, e.g. `meta-llama/Llama-2-7b-hf`).
+ - `in_path` - the folder containing an initially quantized model (corresponds to `--save` of `main.py`).
+ - `out_path` - the folder to save `transformers` model to.
 
-The conversion automatically
+You may also specify flags such as `--save_safetensors` to control the saved model format (see `--help` for details).
+
+Example command: `python convert_to_hf.py meta-llama/Llama-2-7b-hf ./path/to/saved/quantization ./converted-llama2-7b-hf  --save_safetensors
 
 ## Contributing
 


### PR DESCRIPTION
Previously, the explanation would suggest using --keyword arguments but the script does not accept them. It also had an unfinished sentence at the end. This PR finishes the paragraph and clarifies the usage.