### PR TITLE
FIX: Type annotation torch.Any

### DIFF
--- a/inference_lib/src/aqlm/inference.py
+++ b/inference_lib/src/aqlm/inference.py
@@ -1,6 +1,6 @@
 """ Core mathematics for Additive Quantization (AQ): initialization, reconstruction and beam search"""
 import math
-from typing import Optional
+from typing import Any, Optional
 
 import torch
 import torch.nn as nn
@@ -99,7 +99,7 @@ def _get_autograd_matmul_op(forward_pass_kernel, backward_pass_kernel):
     class _QuantizedMatmul(torch.autograd.Function):
         @staticmethod
         def forward(
-            ctx: torch.Any,
+            ctx: Any,
             input: torch.Tensor,
             codes: torch.IntTensor,
             codebooks: torch.Tensor,


### PR DESCRIPTION
See #136.

Use `typing.Any` instead. `torch.Any` fails with torch 2.5.