### PR TITLE
Fix torch.Any which causes AttributeError: module 'torch' has no attribute 'Any' in newer torch versions 

### DIFF
--- a/inference_lib/src/aqlm/inference.py
+++ b/inference_lib/src/aqlm/inference.py
@@ -99,7 +99,7 @@ def _get_autograd_matmul_op(forward_pass_kernel, backward_pass_kernel):
     class _QuantizedMatmul(torch.autograd.Function):
         @staticmethod
         def forward(
-            ctx: torch.Any,
+            ctx,
             input: torch.Tensor,
             codes: torch.IntTensor,
             codebooks: torch.Tensor,


### PR DESCRIPTION
In this PR I deleted the ctx type which was `torch.Any`, but it's causing errors with newer torch versions and causing our CIs to fail. If you have alternatives please let me know. Thank you for your help !