### PR TITLE
Add Kx8 inference kernels

### DIFF
--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cu
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cu
@@ -589,7 +589,7 @@ void  code2x8_matvec_cuda(
   int threads = 32 * thread_m;
   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
   const bool is_turing = cc_major == 7 && cc_minor == 5;
-  if (is_turing) {
+  if (!is_turing) {
     int shared = 16 * (2 * 256 * 8 + 32 * 9);
     cudaFuncSetAttribute(
       Code2x8MatVec<use_bfloat16>, cudaFuncAttributeMaxDynamicSharedMemorySize, shared
@@ -655,7 +655,7 @@ void  code2x8_dequant_cuda(
   int threads = 32 * thread_m;
   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
   const bool is_turing = cc_major == 7 && cc_minor == 5;
-  if (is_turing) {
+  if (!is_turing) {
     int shared = 16 * (2 * 256 * 8 + 32 * 9);
     if (use_bfloat16) {
       cudaFuncSetAttribute(

--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cu
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cu
@@ -6,8 +6,6 @@
 
 #include <iostream>
 
-#include <stdexcept>
-
 template<bool use_bfloat16, size_t group_size>
 __global__ void Code1x16MatVec(
   const int4* __restrict__ A,
@@ -609,9 +607,6 @@ void  code2x8_matvec_cuda(
     cudaFuncSetAttribute(
       CodeKx8MatVec<use_bfloat16, 2>, cudaFuncAttributeMaxDynamicSharedMemorySize, shared
     );
-    if (cudaGetLastError() != cudaSuccess) {
-      throw std::runtime_error("618");
-    }
     CodeKx8MatVec<use_bfloat16, 2><<<blocks, threads, shared, stream>>>(
       (const int4*) A,
       (const int4*) B,
@@ -620,9 +615,6 @@ void  code2x8_matvec_cuda(
       prob_m,
       prob_k
     );
-    if (cudaGetLastError() != cudaSuccess) {
-      throw std::runtime_error("628");
-    }
   }
 }
 
@@ -701,9 +693,6 @@ void  code2x8_dequant_cuda(
         prob_m,
         prob_k
       );
-      if (cudaGetLastError() != cudaSuccess) {
-          throw std::runtime_error("722");
-      }
     } else {
       cudaFuncSetAttribute(
         CodeKx8Dequant<false, 2>, cudaFuncAttributeMaxDynamicSharedMemorySize, shared
@@ -715,9 +704,6 @@ void  code2x8_dequant_cuda(
         prob_m,
         prob_k
       );
-      if (cudaGetLastError() != cudaSuccess) {
-        throw std::runtime_error("748");
-      }
     }
   }
 }

--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cu
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cu
@@ -6,6 +6,8 @@
 
 #include <iostream>
 
+#include <stdexcept>
+
 template<bool use_bfloat16, size_t group_size>
 __global__ void Code1x16MatVec(
   const int4* __restrict__ A,
@@ -295,6 +297,187 @@ __global__ void Code2x8Dequant(
   }
 }
 
+template<bool use_bfloat16>
+__global__ void Code1x8MatVec(
+  const int4* __restrict__ A,
+  const int4* __restrict__ B,
+        int4* __restrict__ C,
+  const int4* __restrict__ codebook,
+  int prob_m,
+  int prob_k,
+  bool add_to_c,
+  size_t enc_offset
+) {
+  int a_gl_stride = prob_k / 8 / 8;
+  int a_gl_rd = (blockDim.x / 32) * blockIdx.x + (threadIdx.x / 32);
+  bool pred = a_gl_rd < prob_m;
+  int b_gl_rd = 0;
+  int c_gl_wr = a_gl_rd;
+  a_gl_rd = a_gl_stride * a_gl_rd + threadIdx.x % 32;
+  int a_gl_end = a_gl_rd + a_gl_stride - threadIdx.x % 32;
+  int lane = threadIdx.x % 8;
+
+  extern __shared__ int4 sh[];
+  int4* sh_b = sh;
+  int4* sh_code = sh_b + 32 * 9;
+
+  for (int i = threadIdx.x; i < 256; i += blockDim.x) {
+    int4 dec = codebook[i];
+    #pragma unroll
+    for (int j = 0; j < 8; j++)
+      sh_code[8 * i + (j + lane) % 8] = dec;
+  }
+  __syncthreads();
+
+  float res = 0;
+
+  int iters = (prob_k / 8 + 8 * 32 - 1) / (8 * 32);
+  while (iters--) {
+    // We pad shared memory to avoid bank conflicts during reads
+    __syncthreads();
+    for (int i = threadIdx.x; i < 32 * 8; i += blockDim.x) {
+      if (b_gl_rd + i < prob_k / 8)
+        sh_b[9 * (i / 8) + i % 8] = B[b_gl_rd + i];
+    }
+    __syncthreads();
+    b_gl_rd += 32 * 8;
+
+    int b_sh_rd = 9 * (threadIdx.x % 32);
+    if (pred && a_gl_rd < a_gl_end) {
+      const uint8_t* enc = reinterpret_cast<const uint8_t*>(&A[a_gl_rd]);
+      #pragma unroll
+      for (int i = 0; i < 8; i++) {
+        if constexpr (use_bfloat16) {
+        #if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800)
+          nv_bfloat162* a = reinterpret_cast<nv_bfloat162*>(&sh_code[8 * enc[2 * i + enc_offset] + lane]);
+          nv_bfloat162* b = reinterpret_cast<nv_bfloat162*>(&sh_b[b_sh_rd]);
+          nv_bfloat162 res2 = {};
+          #pragma unroll
+          for (int j = 0; j < 4; j++)
+            res2 = __hfma2(a[j], b[j], res2);
+          res += __bfloat162float(res2.x) + __bfloat162float(res2.y);
+        #endif
+        } else {
+          half2* a = reinterpret_cast<half2*>(&sh_code[8 * enc[2 * i + enc_offset] + lane]);
+          half2* b = reinterpret_cast<half2*>(&sh_b[b_sh_rd]);
+          half2 res2 = {};
+          #pragma unroll
+          for (int j = 0; j < 4; j++)
+            res2 = __hfma2(a[j], b[j], res2);
+          res += __half2float(res2.x) + __half2float(res2.y);
+        }
+        b_sh_rd++;
+      }
+      a_gl_rd += 32;
+    }
+  }
+
+  if (pred) {
+    #pragma unroll
+    for (int i = 16; i > 0; i /= 2)
+      res += __shfl_down_sync(0xffffffff, res, i);
+    if (threadIdx.x % 32 == 0) {
+      if constexpr (use_bfloat16) {
+        if (add_to_c) {
+        #if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800) 
+          reinterpret_cast<__nv_bfloat16*>(C)[c_gl_wr] = __hadd(
+            reinterpret_cast<__nv_bfloat16*>(C)[c_gl_wr],
+            __float2bfloat16(res)
+          );
+        #endif
+        } else {
+          reinterpret_cast<__nv_bfloat16*>(C)[c_gl_wr] = __float2bfloat16(res);
+        }
+      } else {
+        if (add_to_c) {
+          reinterpret_cast<__half*>(C)[c_gl_wr] = __hadd(
+            reinterpret_cast<__half*>(C)[c_gl_wr],
+            __float2half(res)
+          );
+        } else {
+          reinterpret_cast<__half*>(C)[c_gl_wr] = __float2half(res);
+        }
+      }
+    }
+  }
+}
+
+template<bool use_bfloat16>
+__global__ void Code1x8Dequant(
+  const int4* __restrict__ A,
+        int4* __restrict__ C,
+  const int4* __restrict__ codebook,
+  int prob_m,
+  int prob_k,
+  bool add_to_c,
+  size_t enc_offset
+) {
+  int a_gl_stride = prob_k / 8 / 8;
+  int a_gl_rd = (blockDim.x / 32) * blockIdx.x + (threadIdx.x / 32);
+  bool pred = a_gl_rd < prob_m;
+  a_gl_rd = a_gl_stride * a_gl_rd + threadIdx.x % 32;
+  int a_gl_end = a_gl_rd + a_gl_stride - threadIdx.x % 32;
+  int lane = threadIdx.x % 8;
+
+  int c_gl_stride = prob_k / 8;
+  int c_gl_wr = (blockDim.x / 32) * blockIdx.x + (threadIdx.x / 32);
+  c_gl_wr = c_gl_stride * c_gl_wr + (threadIdx.x % 32) * 8;
+
+  extern __shared__ int4 sh[];
+  int4* sh_code = sh;
+
+  for (int i = threadIdx.x; i < 256; i += blockDim.x) {
+    int4 dec = codebook[i];
+    #pragma unroll
+    for (int j = 0; j < 8; j++)
+      sh_code[8 * i + (j + lane) % 8] = dec;
+  }
+  __syncthreads();
+
+  int iters = (prob_k / 8 - 1) / (8 * 32) + 1;
+  while (iters--) {
+    if (pred && a_gl_rd < a_gl_end) {
+      const uint8_t* enc = reinterpret_cast<const uint8_t*>(&A[a_gl_rd]);
+      #pragma unroll
+      for (int i = 0; i < 8; i++) {
+        int4* c_ptr = &C[a_gl_rd * 8 + i];
+        if constexpr (use_bfloat16) {
+          #if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800)
+            nv_bfloat162* c_bf16_ptr = reinterpret_cast<nv_bfloat162*>(c_ptr);
+            nv_bfloat162* a = reinterpret_cast<nv_bfloat162*>(&sh_code[8 * enc[2 * i + enc_offset] + lane]);
+            if (add_to_c) {
+                #pragma unroll
+                for (int j = 0; j < 4; j++) {
+                  c_bf16_ptr[j] = __hadd2(c_bf16_ptr[j], a[j]);
+                }
+            } else {
+                #pragma unroll
+                for (int j = 0; j < 4; j++) {
+                  c_bf16_ptr[j] = a[j];
+                }
+            }
+          #endif
+        } else {
+          half2* c_fp16_ptr = reinterpret_cast<half2*>(c_ptr);
+          half2* a = reinterpret_cast<half2*>(&sh_code[8 * enc[2 * i + enc_offset] + lane]);
+          if (add_to_c) {
+              #pragma unroll
+              for (int j = 0; j < 4; j++) {
+                c_fp16_ptr[j] = __hadd2(c_fp16_ptr[j], a[j]);
+              }
+          } else {
+              #pragma unroll
+              for (int j = 0; j < 4; j++) {
+                c_fp16_ptr[j] = a[j];
+              }
+          }
+        }
+      }
+    }
+    a_gl_rd += 32;
+  }
+}
+
 inline int ceildiv(int a, int b) {
   return (a + b - 1) / b;
 }
@@ -391,6 +574,8 @@ void  code2x8_matvec_cuda(
 ) {
   int cc_major;
   cudaDeviceGetAttribute(&cc_major, cudaDevAttrComputeCapabilityMajor, 0);
+  int cc_minor;
+  cudaDeviceGetAttribute(&cc_minor, cudaDevAttrComputeCapabilityMinor, 0);
   if (cc_major < 8 && use_bfloat16) {
     throw c10::TypeError(
       {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},
@@ -411,19 +596,56 @@ void  code2x8_matvec_cuda(
 
   int blocks = ceildiv(prob_m, thread_m);
   int threads = 32 * thread_m;
-  int shared = 16 * (2 * 256 * 8 + 32 * 9);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
-  cudaFuncSetAttribute(
-    Code2x8MatVec<use_bfloat16>, cudaFuncAttributeMaxDynamicSharedMemorySize, shared
-  );
-  Code2x8MatVec<use_bfloat16><<<blocks, threads, shared, stream>>>(
-    (const int4*) A,
-    (const int4*) B,
-    (int4*) C,
-    (const int4*) codebook,
-    prob_m,
-    prob_k
-  );
+  const bool is_turing = cc_major == 7 && cc_minor == 5;
+  if (is_turing) {
+    int shared = 16 * (2 * 256 * 8 + 32 * 9);
+    cudaFuncSetAttribute(
+      Code2x8MatVec<use_bfloat16>, cudaFuncAttributeMaxDynamicSharedMemorySize, shared
+    );
+    Code2x8MatVec<use_bfloat16><<<blocks, threads, shared, stream>>>(
+      (const int4*) A,
+      (const int4*) B,
+      (int4*) C,
+      (const int4*) codebook,
+      prob_m,
+      prob_k
+    );
+  } else {
+    int shared = 16 * (256 * 8 + 32 * 9);
+    cudaFuncSetAttribute(
+      Code1x8MatVec<use_bfloat16>, cudaFuncAttributeMaxDynamicSharedMemorySize, shared
+    );
+    if (cudaGetLastError() != cudaSuccess) {
+      throw std::runtime_error("618");
+    }
+    Code1x8MatVec<use_bfloat16><<<blocks, threads, shared, stream>>>(
+      (const int4*) A,
+      (const int4*) B,
+      (int4*) C,
+      (const int4*) codebook,
+      prob_m,
+      prob_k,
+      false,
+      0
+    );
+    if (cudaGetLastError() != cudaSuccess) {
+      throw std::runtime_error("628");
+    }
+    Code1x8MatVec<use_bfloat16><<<blocks, threads, shared, stream>>>(
+      (const int4*) A,
+      (const int4*) B,
+      (int4*) C,
+      (const int4*) codebook + 256,
+      prob_m,
+      prob_k,
+      true,
+      1
+    );
+    if (cudaGetLastError() != cudaSuccess) {
+      throw std::runtime_error("640");
+    }
+  }
 }
 
 template void code2x8_matvec_cuda<false>(const void*, const void*, void*, const void*, int, int);
@@ -439,6 +661,8 @@ void  code2x8_dequant_cuda(
 ) {
   int cc_major;
   cudaDeviceGetAttribute(&cc_major, cudaDevAttrComputeCapabilityMajor, 0);
+  int cc_minor;
+  cudaDeviceGetAttribute(&cc_minor, cudaDevAttrComputeCapabilityMinor, 0);
   if (cc_major < 8 && use_bfloat16) {
     throw c10::TypeError(
       {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},
@@ -459,29 +683,91 @@ void  code2x8_dequant_cuda(
 
   int blocks = ceildiv(prob_m, thread_m);
   int threads = 32 * thread_m;
-  int shared = 16 * (2 * 256 * 8 + 32 * 9);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
-  if (use_bfloat16) {
-    cudaFuncSetAttribute(
-      Code2x8Dequant<true>, cudaFuncAttributeMaxDynamicSharedMemorySize, shared
-    );
-    Code2x8Dequant<true><<<blocks, threads, shared, stream>>>(
-      (const int4*) A,
-      (int4*) C,
-      (const int4*) codebook,
-      prob_m,
-      prob_k
-    );
+  const bool is_turing = cc_major == 7 && cc_minor == 5;
+  if (is_turing) {
+    int shared = 16 * (2 * 256 * 8 + 32 * 9);
+    if (use_bfloat16) {
+      cudaFuncSetAttribute(
+        Code2x8Dequant<true>, cudaFuncAttributeMaxDynamicSharedMemorySize, shared
+      );
+      Code2x8Dequant<true><<<blocks, threads, shared, stream>>>(
+        (const int4*) A,
+        (int4*) C,
+        (const int4*) codebook,
+        prob_m,
+        prob_k
+      );
+    } else {
+      cudaFuncSetAttribute(
+        Code2x8Dequant<false>, cudaFuncAttributeMaxDynamicSharedMemorySize, shared
+      );
+      Code2x8Dequant<false><<<blocks, threads, shared, stream>>>(
+        (const int4*) A,
+        (int4*) C,
+        (const int4*) codebook,
+        prob_m,
+        prob_k
+      );
+    }
   } else {
-    cudaFuncSetAttribute(
-      Code2x8Dequant<false>, cudaFuncAttributeMaxDynamicSharedMemorySize, shared
-    );
-    Code2x8Dequant<false><<<blocks, threads, shared, stream>>>(
-      (const int4*) A,
-      (int4*) C,
-      (const int4*) codebook,
-      prob_m,
-      prob_k
-    );
+    int shared = 16 * (256 * 8 + 32 * 9);
+    if (use_bfloat16) {
+      cudaFuncSetAttribute(
+        Code1x8Dequant<true>, cudaFuncAttributeMaxDynamicSharedMemorySize, shared
+      );
+      Code1x8Dequant<true><<<blocks, threads, shared, stream>>>(
+        (const int4*) A,
+        (int4*) C,
+        (const int4*) codebook,
+        prob_m,
+        prob_k, 
+        false,
+        0
+      );
+      if (cudaGetLastError() != cudaSuccess) {
+          throw std::runtime_error("722");
+      }
+      Code1x8Dequant<true><<<blocks, threads, shared, stream>>>(
+        (const int4*) A,
+        (int4*) C,
+        (const int4*) codebook + 256,
+        prob_m,
+        prob_k, 
+        true,
+        1
+      );
+      if (cudaGetLastError() != cudaSuccess) {
+        throw std::runtime_error("733");
+      }
+    } else {
+      cudaFuncSetAttribute(
+        Code1x8Dequant<false>, cudaFuncAttributeMaxDynamicSharedMemorySize, shared
+      );
+      Code1x8Dequant<false><<<blocks, threads, shared, stream>>>(
+        (const int4*) A,
+        (int4*) C,
+        (const int4*) codebook,
+        prob_m,
+        prob_k,
+        false,
+        0
+      );
+      if (cudaGetLastError() != cudaSuccess) {
+        throw std::runtime_error("748");
+      }
+      Code1x8Dequant<false><<<blocks, threads, shared, stream>>>(
+        (const int4*) A,
+        (int4*) C,
+        (const int4*) codebook + 256,
+        prob_m,
+        prob_k,
+        true,
+        1
+      );
+      if (cudaGetLastError() != cudaSuccess) {
+        throw std::runtime_error("759");
+      }
+    }
   }
 }


### PR DESCRIPTION
Currently, 2x8 configuration does not work on Turing GPUs because of the limited [maximum amount of shared memory per SM](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications-technical-specifications-per-compute-capability) available on the Compute Capability 7.5.
This PR adds Kx8 inference CUDA kernels and uses them as a fallback for the 2x8 configuration on Turing GPUs.
Thus, this configuration can be run on T4, which is the default Google Colab GPU.

Moreover, these kernels can also be used later to infer any Kx8 configuration.

This PR also integrates patch from https://github.com/Vahe1994/AQLM/pull/139.

[Example notebook](https://colab.research.google.com/drive/1uhKjtblkWFrMu2RhSBz5cUkHaXi9TDsG?usp=sharing)