### PR TITLE
Support 1bit-1x8 configuration

### DIFF
--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.cpp
@@ -71,6 +71,27 @@ void code2x8_dequant_cuda(
   bool use_bfloat16
 );
 
+template <bool use_bfloat16>
+void code1x8_matvec_cuda(
+  const void* A,
+  const void* B,
+        void* C,
+  const void* codebook,
+  int prob_m,
+  int prob_k
+);
+extern template void code1x8_matvec_cuda<false>(const void*, const void*, void*, const void*, int, int);
+extern template void code1x8_matvec_cuda<true>(const void*, const void*, void*, const void*, int, int);
+
+void code1x8_dequant_cuda(
+  const void* A,
+        void* C,
+  const void* codebook,
+  int prob_m,
+  int prob_k,
+  bool use_bfloat16
+);
+
 inline torch::Tensor scale_bias_unflatten_output(
         torch::Tensor& flat_output,
   const torch::Tensor& scales,
@@ -497,6 +518,171 @@ torch::Tensor code2x8_matmat_dequant_transposed(
   return F::linear(input, weight.transpose(0, 1), bias_2);
 }
 
+void code1x8_matvec(
+  const torch::Tensor& A,
+  const torch::Tensor& B,
+        torch::Tensor& C,
+  const torch::Tensor& codebook,
+  bool use_bfloat16
+) {
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
+  int prob_m = C.size(0);
+  int prob_k = B.size(0);
+  if (use_bfloat16) {
+    code1x8_matvec_cuda<true>(
+      A.data_ptr(),
+      B.data_ptr(),
+      C.data_ptr(),
+      codebook.data_ptr(),
+      prob_m,
+      prob_k
+    );
+  } else {
+    code1x8_matvec_cuda<false>(
+      A.data_ptr(),
+      B.data_ptr(),
+      C.data_ptr(),
+      codebook.data_ptr(),
+      prob_m,
+      prob_k
+    );
+  }
+}
+
+torch::Tensor code1x8_matmat(
+  const torch::Tensor& input,
+  const torch::Tensor& codes,
+  const torch::Tensor& codebooks,
+  const torch::Tensor& scales,
+  const std::optional<torch::Tensor>& bias
+) {
+  bool use_bfloat16 = check_use_bfloat16(input);
+  auto input_sizes = input.sizes();
+  auto out_features = codes.size(0) * codebooks.size(2);
+  auto flat_input = input.reshape({-1, input.size(-1)});
+  auto flat_output = torch::empty({flat_input.size(0), out_features},
+    torch::TensorOptions()
+      .dtype(input.dtype())
+      .device(input.device())
+  );
+
+  for (int i = 0; i < flat_input.size(0); ++i) {
+    auto input_vec = flat_input.index({i});
+    auto output_vec = flat_output.index({i});
+    code1x8_matvec(
+      codes.squeeze(2),
+      input_vec,
+      output_vec,
+      codebooks,
+      use_bfloat16
+    );
+  }
+  return scale_bias_unflatten_output(
+    flat_output,
+    scales,
+    bias,
+    input_sizes
+  );
+}
+
+torch::Tensor code1x8_dequant(
+  const torch::Tensor& codes,
+  const torch::Tensor& codebooks,
+  const torch::Tensor& scales
+) {
+  auto use_bfloat16 = check_use_bfloat16(codebooks);
+  auto in_features = codes.size(1) * 8;
+  auto out_features = scales.size(0);
+
+  auto weight = torch::empty({out_features, in_features},
+    torch::TensorOptions()
+      .dtype(codebooks.dtype())
+      .device(codebooks.device())
+  );
+  code1x8_dequant_cuda(
+    codes.data_ptr(),
+    weight.data_ptr(),
+    codebooks.data_ptr(),
+    out_features,
+    in_features,
+    use_bfloat16
+  );
+  weight *= scales.index({"...", 0, 0});
+
+  return weight;
+}
+
+torch::Tensor code1x8_matmat_dequant(
+  const torch::Tensor& input,
+  const torch::Tensor& codes,
+  const torch::Tensor& codebooks,
+  const torch::Tensor& scales,
+  const std::optional<torch::Tensor>& bias
+) {
+  bool use_bfloat16 = check_use_bfloat16(input);
+  auto input_sizes = input.sizes();
+  auto in_features = codes.size(1) * 8;
+  auto out_features = codes.size(0) * codebooks.size(2);
+  auto flat_input = input.reshape({-1, input.size(-1)});
+
+  auto weight = torch::empty({out_features, in_features},
+    torch::TensorOptions()
+      .dtype(codebooks.dtype())
+      .device(codebooks.device())
+  );
+  code1x8_dequant_cuda(
+    codes.data_ptr(),
+    weight.data_ptr(),
+    codebooks.data_ptr(),
+    out_features,
+    in_features,
+    use_bfloat16
+  );
+
+  auto flat_output = F::linear(flat_input, weight);
+  return scale_bias_unflatten_output(
+    flat_output,
+    scales,
+    bias,
+    input_sizes
+  );
+}
+
+torch::Tensor code1x8_matmat_dequant_transposed(
+  const torch::Tensor& input,
+  const torch::Tensor& codes,
+  const torch::Tensor& codebooks,
+  const torch::Tensor& scales,
+  const std::optional<torch::Tensor>& bias
+) {
+  auto use_bfloat16 = check_use_bfloat16(codebooks);
+  auto input_sizes = input.sizes();
+  auto in_features = codes.size(1) * 8;
+  auto out_features = scales.size(0);
+  auto scaled_input = (input.reshape({-1, input.size(-1)}) * scales.flatten().unsqueeze(0)).reshape(input_sizes);
+
+  auto weight = torch::empty({out_features, in_features},
+    torch::TensorOptions()
+      .dtype(codebooks.dtype())
+      .device(codebooks.device())
+  );
+  code1x8_dequant_cuda(
+    codes.data_ptr(),
+    weight.data_ptr(),
+    codebooks.data_ptr(),
+    out_features,
+    in_features,
+    use_bfloat16
+  );
+
+  torch::Tensor bias_2{};
+  if (bias.has_value()) {
+    bias_2 = bias.value();
+  }
+
+  return F::linear(input, weight.transpose(0, 1), bias_2);
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("code1x16_matmat", &code1x16_matmat, "1x16 (2bit) codebook matrix-matrix product through matvec.");
   m.def("code1x16_dequant", &code1x16_dequant, "1x16 (2bit) codebook dequantization.");
@@ -506,4 +692,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("code2x8_dequant", &code2x8_dequant, "2x8 (2bit) codebook dequantization.");
   m.def("code2x8_matmat_dequant", &code2x8_matmat_dequant, "2x8 (2bit) codebook matrix-matrix dequantization product.");
   m.def("code2x8_matmat_dequant_transposed", &code2x8_matmat_dequant_transposed, "2x8 (2bit) codebook matrix-matrix dequantization product for backward pass.");
+  m.def("code1x8_matmat", &code1x8_matmat, "1x8 (1bit) codebook matrix-matrix product.");
+  m.def("code1x8_dequant", &code1x8_dequant, "1x8 (1bit) codebook dequantization.");
+  m.def("code1x8_matmat_dequant", &code1x8_matmat_dequant, "1x8 (1bit) codebook matrix-matrix dequantization product.");
+  m.def("code1x8_matmat_dequant_transposed", &code1x8_matmat_dequant_transposed, "1x8 (1bit) codebook matrix-matrix dequantization product for backward pass.");
 }

--- a/inference_lib/src/aqlm/inference_kernels/cuda_kernel.py
+++ b/inference_lib/src/aqlm/inference_kernels/cuda_kernel.py
@@ -90,3 +90,43 @@ def code2x8_matmat_dequant_transposed_meta(input, codes, codebooks, scales, bias
     return torch.empty(
         input.shape[:-1] + (codes.shape[1] * codebooks.shape[3],), device=input.device, dtype=input.dtype
     )
+
+
+torch.library.define(
+    "aqlm::code1x8_matmat", "(Tensor input, Tensor codes, Tensor codebooks, Tensor scales, Tensor bias) -> Tensor"
+)
+
+torch.library.impl("aqlm::code1x8_matmat", "default", CUDA_KERNEL.code1x8_matmat)
+
+
+@torch.library.impl_abstract("aqlm::code1x8_matmat")
+def code1x8_matmat_meta(input, codes, codebooks, scales, bias):
+    return torch.empty(input.shape[:-1] + (codes.shape[0],), device=input.device, dtype=input.dtype)
+
+
+torch.library.define(
+    "aqlm::code1x8_matmat_dequant",
+    "(Tensor input, Tensor codes, Tensor codebooks, Tensor scales, Tensor bias) -> Tensor",
+)
+
+torch.library.impl("aqlm::code1x8_matmat_dequant", "default", CUDA_KERNEL.code1x8_matmat_dequant)
+
+
+@torch.library.impl_abstract("aqlm::code1x8_matmat_dequant")
+def code1x8_matmat_dequant_meta(input, codes, codebooks, scales, bias):
+    return torch.empty(input.shape[:-1] + (codes.shape[0],), device=input.device, dtype=input.dtype)
+
+
+torch.library.define(
+    "aqlm::code1x8_matmat_dequant_transposed",
+    "(Tensor input, Tensor codes, Tensor codebooks, Tensor scales, Tensor bias) -> Tensor",
+)
+
+torch.library.impl("aqlm::code1x8_matmat_dequant_transposed", "default", CUDA_KERNEL.code1x8_matmat_dequant_transposed)
+
+
+@torch.library.impl_abstract("aqlm::code1x8_matmat_dequant_transposed")
+def code1x8_matmat_dequant_transposed_meta(input, codes, codebooks, scales, bias):
+    return torch.empty(
+        input.shape[:-1] + (codes.shape[1] * codebooks.shape[3],), device=input.device, dtype=input.dtype
+    )

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -62,10 +62,32 @@ def get_forward_pass_kernel(
         codebook_size,
         out_group_size,
         in_group_size,
+    ) == (False, "cuda", 1, 256, 1, 8):
+        from .cuda_kernel import CUDA_FOLDER
+
+        return torch.ops.aqlm.code1x8_matmat
+    elif (
+        optimize_for_training,
+        codebooks.device.type,
+        num_codebooks,
+        codebook_size,
+        out_group_size,
+        in_group_size,
     ) == (True, "cuda", 2, 256, 1, 8):
         from .cuda_kernel import CUDA_FOLDER
 
         return torch.ops.aqlm.code2x8_matmat_dequant
+    elif (
+        optimize_for_training,
+        codebooks.device.type,
+        num_codebooks,
+        codebook_size,
+        out_group_size,
+        in_group_size,
+    ) == (True, "cuda", 1, 256, 1, 8):
+        from .cuda_kernel import CUDA_FOLDER
+
+        return torch.ops.aqlm.code1x8_matmat_dequant
     elif (optimize_for_training, codebooks.device.type, out_group_size) == (False, "cuda", 1):
         from .triton_kernel import triton_matmul
 
@@ -107,6 +129,17 @@ def get_backward_pass_kernel(
         from .cuda_kernel import CUDA_FOLDER
 
         return torch.ops.aqlm.code2x8_matmat_dequant_transposed
+    elif (
+        optimize_for_training,
+        codebooks.device.type,
+        num_codebooks,
+        codebook_size,
+        out_group_size,
+        in_group_size,
+    ) == (True, "cuda", 1, 256, 1, 8):
+        from .cuda_kernel import CUDA_FOLDER
+
+        return torch.ops.aqlm.code1x8_matmat_dequant_transposed
     else:
         forward_pass_kernel = get_forward_pass_kernel(
             codebooks=codebooks.transpose(2, 3), optimize_for_training=optimize_for_training


### PR DESCRIPTION
This PR adopts existing Kx8 kernels for inference of `ISTA-DASLab/Llama-2-7b-AQLM-PV-2Bit-2x8-hf` model.

Colab example: [link](https://colab.research.google.com/drive/1tGlv1VRAPEusiukGX2ObThc3TRkQfVSC?usp=sharing).