### PR TITLE
fix: set `weights_only=False` in `convert_to_hf.py`

### DIFF
--- a/convert_to_hf.py
+++ b/convert_to_hf.py
@@ -55,7 +55,7 @@ def get_converted_state_dict(config, nbits: int, in_path: os.PathLike) -> [dict,
     layers_prefix = get_layers_prefix(config)
 
     for i in trange(num_layers):
-        layer = torch.load(os.path.join(in_path, f"{i}.pth"))
+        layer = torch.load(os.path.join(in_path, f"{i}.pth"), weights_only=False)
         for name, p in layer.named_parameters():
             if torch.is_floating_point(p.data):
                 p.data = p.data.half()


### PR DESCRIPTION
When running convert_to_hf.py I've faced the error 
```
File "/workspace/quantization/quantize/AQLM/convert_to_hf.py", line 58, in get_converted_state_dict
    layer = torch.load(os.path.join(in_path, f"{i}.pth"))
  File "/usr/local/lib/python3.10/dist-packages/torch/serialization.py", line 1470, in load
    raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint.
```

setting the weights_only=False as proposed has fixed the error
```
(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
```

Another way to fix the error is to set the maximum for torch version in requirements.txt, however it seems overcomplicated to me and setting flag to False is more elegant solution