### PR TITLE
enable triton kernel on XPU

### DIFF
--- a/inference_lib/src/aqlm/inference.py
+++ b/inference_lib/src/aqlm/inference.py
@@ -92,7 +92,8 @@ class QuantizedLinear(nn.Module):
             get_backward_pass_kernel(self.codebooks, True),
         )
 
-        self.use_gemv_rule = lambda input: math.prod(input.shape[:-1]) <= 6
+        threshold = 224 if input.device.type == "xpu" else 6
+        self.use_gemv_rule = lambda input: math.prod(input.shape[:-1]) <= threshold
 
 
 def _get_autograd_matmul_op(forward_pass_kernel, backward_pass_kernel):

--- a/inference_lib/src/aqlm/inference.py
+++ b/inference_lib/src/aqlm/inference.py
@@ -92,7 +92,7 @@ class QuantizedLinear(nn.Module):
             get_backward_pass_kernel(self.codebooks, True),
         )
 
-        threshold = 224 if input.device.type == "xpu" else 6
+        threshold = 256 if input.device.type == "xpu" else 6
         self.use_gemv_rule = lambda input: math.prod(input.shape[:-1]) <= threshold
 
 

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -88,7 +88,7 @@ def get_forward_pass_kernel(
         from .cuda_kernel import CUDA_FOLDER
 
         return torch.ops.aqlm.code1x8_matmat_dequant
-    elif (optimize_for_training, codebooks.device.type, out_group_size) == (False, "cuda", 1):
+    elif (optimize_for_training, out_group_size) == (False, 1) and codebooks.device.type in ("cuda", "xpu"):
         from .triton_kernel import triton_matmul
 
         return triton_matmul

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -88,7 +88,7 @@ def get_forward_pass_kernel(
         from .cuda_kernel import CUDA_FOLDER
 
         return torch.ops.aqlm.code1x8_matmat_dequant
-    elif (optimize_for_training, out_group_size) == (False, 1) and codebooks.device.type in ("cuda", "xpu"):
+    elif out_group_size == 1 and codebooks.device.type in ("cuda", "xpu"):
         from .triton_kernel import triton_matmul
 
         return triton_matmul

--- a/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
+++ b/inference_lib/src/aqlm/inference_kernels/kernel_selector.py
@@ -88,7 +88,7 @@ def get_forward_pass_kernel(
         from .cuda_kernel import CUDA_FOLDER
 
         return torch.ops.aqlm.code1x8_matmat_dequant
-    elif out_group_size == 1 and codebooks.device.type in ("cuda", "xpu"):
+    elif (optimize_for_training, out_group_size) == (False, 1) and codebooks.device.type in ("cuda", "xpu"):
         from .triton_kernel import triton_matmul
 
         return triton_matmul


### PR DESCRIPTION
The triton kernel also works on Intel XPU and could bring 10x speed-up compared to pytorch implementation.